### PR TITLE
citationformatter: utf-8 special characters mangled

### DIFF
--- a/zenodo/modules/citationformatter/views.py
+++ b/zenodo/modules/citationformatter/views.py
@@ -58,6 +58,7 @@ def format():
             style=style,
         )
     )
+    r.encoding = 'utf-8'
 
     if r.status_code == 200:
         return (r.text, 200, [('content-type', 'text/plain')])


### PR DESCRIPTION
- Adds the utf-8 encoding in http request

Signed-off-by: Adrian Pawel Baran adrian.pawel.baran@cern.ch
