### PR TITLE
base: pub links on brief format fix

### DIFF
--- a/zenodo/base/format_elements/bfe_openaire_access_rights.py
+++ b/zenodo/base/format_elements/bfe_openaire_access_rights.py
@@ -25,9 +25,10 @@ import time
 
 from flask import current_app
 from invenio.base.i18n import gettext_set_language
+from flask import url_for
 
 
-def format_element(bfo, as_label=False, only_restrictions=False):
+def format_element(bfo, as_label=False, only_restrictions=False, brief=False):
     CFG_ACCESS_RIGHTS = current_app.config['CFG_ACCESS_RIGHTS']
     ln = bfo.lang
     _ = gettext_set_language(ln)
@@ -42,6 +43,7 @@ def format_element(bfo, as_label=False, only_restrictions=False):
     submitter = bfo.field('8560_f')
     email = """<a href="mailto:%s">%s</a>""" % (cgi.escape(submitter, True), cgi.escape(submitter))
     access = _(dict(current_app.config['CFG_ACCESS_RIGHTS'])[access_rights])
+    url = url_for('record.metadata', recid=bfo.recID)
 
     if only_restrictions:
         if access_rights in ('embargoedAccess', 'embargoed'):
@@ -50,13 +52,25 @@ def format_element(bfo, as_label=False, only_restrictions=False):
             return """<dt>Restricted access</dt><dd>Please contact %s to access the files.</dd>""" % email
     elif as_label:
         if access_rights in ('embargoedAccess', 'embargoed'):
-            return """<a href="/search?p=542__l:embargoed" class="label label-warning" rel="tooltip" title="Available as Open Access after %s">%s</a>""" % (embargo, _(access))
+            if brief:
+                return """<a href="%s" class="label label-warning" rel="tooltip" title="Available as Open Access after %s">%s</a>""" % (url, embargo, _(access))
+            else:
+                return """<a href="/search?p=542__l:embargoed" class="label label-warning" rel="tooltip" title="Available as Open Access after %s">%s</a>""" % (embargo, _(access))
         elif access_rights in ('closedAccess', 'closed'):
-            return """<a href="/search?p=542__l:closed" class="label label-danger">%s</a>""" % _(access)
+            if brief:
+                return """<a href="%s" class="label label-danger">%s</a>""" % (url, access)
+            else:
+                return """<a href="/search?p=542__l:closed" class="label label-danger">%s</a>""" % _(access)
         elif access_rights in ('openAccess', 'open'):
-            return """<a href="/search?p=542__l:open" class="label label-success">%s</a>""" % _(access)
+            if brief:
+                return """<a href="%s" class="label label-success">%s</a>""" % (url, access)
+            else:
+                return """<a href="/search?p=542__l:open" class="label label-success">%s</a>""" % _(access)
         elif access_rights in ('restricteDaccess', 'restricted'):
-            return """<a href="/search?p=542__l:restricted" class="label label-warning">%s</a>""" % _(access)
+            if brief:
+                return """<a href="%s" class="label label-warning">%s</a>""" % (url, access)
+            else:
+                return """<a href="/search?p=542__l:restricted" class="label label-warning">%s</a>""" % _(access)
         elif access_rights == 'cc0':
             return """<a class="label label-success">%s</a>""" % _(access)
     else:

--- a/zenodo/base/format_elements/bfe_openaire_pubtype.py
+++ b/zenodo/base/format_elements/bfe_openaire_pubtype.py
@@ -22,8 +22,9 @@
 
 from flask import current_app
 from invenio.base.i18n import _
+from flask import url_for
 
-def format_element(bfo, as_label=False):
+def format_element(bfo, as_label=False, brief=False):
     ln = bfo.lang
     collections = bfo.fields('980__')
 
@@ -42,13 +43,16 @@ def format_element(bfo, as_label=False):
 
             name = _(dict(CFG_OPENAIRE_PUBTYPE_MAP)[collection])
             query = "980__a:%s" % collection
+            url = url_for('record.metadata', recid=bfo.recID)
 
             if subcollection:
                 name = _(dict(CFG_OPENAIRE_PUBTYPE_MAP)[subcollection])
                 query = "980__b:%s" % subcollection
-
             if as_label:
-                return """<a href="/search?p=%s" class="label label-inverse">%s</a>""" % (query, name)
+                if brief:
+                    return """<a href="%s" class="label label-inverse">%s</a>""" % (url, name)
+                else:
+                    return """<a href="/search?p=%s" class="label label-inverse">%s</a>""" % (query, name)
             else:
                 return name
         except KeyError:

--- a/zenodo/base/templates/format/record/Default_HTML_brief.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_brief.tpl
@@ -1,3 +1,25 @@
+{#
+## This file is part of ZENODO.
+## Copyright (C) 2012, 2013, 2014 CERN.
+##
+## ZENODO is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## ZENODO is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+##
+## In applying this licence, CERN does not waive the privileges and immunities
+## granted to it by virtue of its status as an Intergovernmental Organization
+## or submit itself to any jurisdiction.
+#}
+
 <div class="media htmlbrief">
     <span class="pull-left hidden-sm">
         {{ bfe_icon(bfo, subformat_re='icon-90') }}
@@ -7,12 +29,12 @@
     </span>
     <div class="media-body">
         <span class="label label-info" data-toggle="tooltip" title="Publication date">{{ bfe_date(bfo, date_format='%d %B %Y') }}</span>
-        {{ bfe_openaire_pubtype(bfo, as_label="1") }}
-        {{ bfe_openaire_access_rights(bfo, as_label="1") }}
+        {{ bfe_openaire_pubtype(bfo, as_label="1", brief="1") }}
+        {{ bfe_openaire_access_rights(bfo, as_label="1", brief="1") }}
         <br>
         <h4 class="media-heading muted_a"><a href="{{ bfe_record_url(bfo, ) }}">{{ bfe_title_brief(bfo, highlight="no") }}</a></h4>
         <p>{{ bfe_authors(bfo, limit="4", extension="; et al. ", highlight="no") }}</p>
         <p class="muted_a"><a href="{{ bfe_record_url(bfo, ) }}">{{ bfo.field('520__a').decode('utf8')|striptags|truncate }}</a></p>
-        {% if bfo.field('8560_y') %}<small class="text-muted">Uploaded by <a href="{{ url_for('yourmessages.write', sent_to_user_nicks=bfo.field('8560_y')) }}">{{bfo.field('8560_y').decode('utf8')}}</a> on {{ bfe_creation_date(bfo, date_format="%d %M %Y") }}.</small>{% endif %}
+        {% if bfo.field('8560_y') %}<small class="text-muted">Uploaded by {{bfo.field('8560_y').decode('utf8')}} on {{ bfe_creation_date(bfo, date_format="%d %M %Y") }}.</small>{% endif %}
     </div>
 </div>


### PR DESCRIPTION
- Fixes links in `access rights` and `pubtype` field.
- Removes link from `uploaded by` field.

Signed-off-by: Adrian Pawel Baran adrian.pawel.baran@cern.ch

<!---
@huboard:{"milestone_order":16.0,"order":43.0,"custom_state":""}
-->
