### PR TITLE
installation: removal of doubled up requirements

### DIFF
--- a/base.requirements.txt
+++ b/base.requirements.txt
@@ -93,8 +93,6 @@ importlib==1.0.3
 infinity==1.3
 intbitset==2.1.1
 intervals==0.3.1
-ipdb==0.8
-ipython==2.3.0
 isodate==0.5.0
 itsdangerous==0.24
 jellyfish==0.3.2


### PR DESCRIPTION
- Removes `ipdb` and `ipython` from `base.requirements.txt`,
  as they already exist in `dev.requirements.txt`. (closes #54)

Signed-off-by: Adrian Pawel Baran adrian.pawel.baran@cern.ch
