### PR TITLE
base: css text overflow fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 ZENODO
 ======
 
-.. image:: https://travis-ci.org/zenodo/zenodo.png?branch=master
-    :target: https://travis-ci.org/zenodo/zenodo
+.. image:: https://api.shippable.com/projects/5477dd61d46935d5fbbed43b/badge?branchName=master
+    :target: https://app.shippable.com/projects/5477dd61d46935d5fbbed43b/builds/latest
 .. image:: https://coveralls.io/repos/zenodo/zenodo/badge.png?branch=master
     :target: https://coveralls.io/r/zenodo/zenodo
 

--- a/zenodo/base/static/less/zenodo.less
+++ b/zenodo/base/static/less/zenodo.less
@@ -94,7 +94,23 @@ h4.repo {
   margin-bottom: 5px;
 }
 
+.nowrap {
+    white-space: nowrap;
+}
 
+.forcewrap {
+    -ms-word-break: break-all;
+
+    /* Be VERY careful with this, breaks normal words wh_erever */
+    word-break: break-all;
+
+    /* Non standard for webkit */
+    word-break: break-word;
+
+    -webkit-hyphens: auto;
+       -moz-hyphens: auto;
+            hyphens: auto;
+}
 
 .rmlink {
   color: #000;

--- a/zenodo/base/templates/records/base.html
+++ b/zenodo/base/templates/records/base.html
@@ -69,10 +69,10 @@
         <tbody>
         {%- for file in zenodo_files|sort(attribute='comment') -%}
           <tr class="">
-              <td><a href="{{file.get_url()}}">{{ file.get_full_name() }}</a></td>
-              <td>{{ file.md.strftime('%d %b %Y') }}</td>
-              <td>{{ file.size|filesizeformat }}</td>
-              <td><span class="pull-right">{% if file.get_superformat().lower() in config.CFG_PREVIEW_PREFERENCE %}<button class="btn preview-link btn-default" data-filename="{{file.get_full_name()}}"><i class="fa fa-eye"></i> {{_("Preview")}}</button>{% endif %} <a class="btn btn-default" href="{{file.get_url()}}"><i class="fa fa-download"></i> {{_("Download")}}</a></span></td>
+              <td><a class="forcewrap" href="{{file.get_url()}}">{{ file.get_full_name() }}</a></td>
+              <td class="nowrap">{{ file.md.strftime('%d %b %Y') }}</td>
+              <td class="nowrap">{{ file.size|filesizeformat }}</td>
+              <td class="nowrap"><span class="pull-right">{% if file.get_superformat().lower() in config.CFG_PREVIEW_PREFERENCE %}<button class="btn preview-link btn-xs btn-default" data-filename="{{file.get_full_name()}}"><i class="fa fa-eye"></i> {{_("Preview")}}</button>{% endif %} <a class="btn btn-xs btn-default" href="{{file.get_url()}}"><i class="fa fa-download"></i> {{_("Download")}}</a></span></td>
             </tr>
           {%- endfor -%}
           </tbody>

--- a/zenodo/modules/deposit/templates/deposit/widget_plupload_index.html
+++ b/zenodo/modules/deposit/templates/deposit/widget_plupload_index.html
@@ -57,8 +57,8 @@
   <table id="uploader-filelist" class="table table-striped table-condensed">
     <thead>
       <tr>
-        <th>Filename</th>
-        <th>Size</th>
+        <th>{{ _('Filename') }}</th>
+        <th>{{ _('Size') }}</th>
         <th></th>
         <th></th>
       </tr>


### PR DESCRIPTION
- Fixes issue with long file names overflowing widget. (closes #71)
- Changes build badge from travis to shippable.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
