### PR TITLE
deposit: rename ObjectVersion FINAL to COMPLETED

### DIFF
--- a/zenodo/modules/deposit/testsuite/test_zenodo_api.py
+++ b/zenodo/modules/deposit/testsuite/test_zenodo_api.py
@@ -739,7 +739,7 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
         )
 
         self.assert_workflow_status(
-            res_id, ObjectVersion.FINAL, WorkflowStatus.COMPLETED
+            res_id, ObjectVersion.COMPLETED, WorkflowStatus.COMPLETED
         )
 
         self.run_deposition_tasks(res_id)
@@ -1087,7 +1087,7 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
         from invenio.modules.workflows.engine import ObjectVersion, \
             WorkflowStatus
         self.assert_workflow_status(
-            res_id, ObjectVersion.FINAL, WorkflowStatus.COMPLETED
+            res_id, ObjectVersion.COMPLETED, WorkflowStatus.COMPLETED
         )
 
         # Second request will return forbidden since it's already published
@@ -1161,7 +1161,7 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
         )
 
         self.assert_workflow_status(
-            res_id, ObjectVersion.FINAL, WorkflowStatus.COMPLETED
+            res_id, ObjectVersion.COMPLETED, WorkflowStatus.COMPLETED
         )
 
         self.run_deposition_tasks(res_id)
@@ -1258,7 +1258,7 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
         from invenio.modules.workflows.engine import ObjectVersion, \
             WorkflowStatus
         self.assert_workflow_status(
-            res_id, ObjectVersion.FINAL, WorkflowStatus.COMPLETED
+            res_id, ObjectVersion.COMPLETED, WorkflowStatus.COMPLETED
         )
 
         # Edit deposition - not possible yet (until fully integrated)
@@ -1412,7 +1412,7 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
         )
 
         self.assert_workflow_status(
-            res_id, ObjectVersion.FINAL, WorkflowStatus.COMPLETED
+            res_id, ObjectVersion.COMPLETED, WorkflowStatus.COMPLETED
         )
 
         # Edit deposition - not possible yet (until fully integrated)
@@ -1499,7 +1499,7 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
         )
 
         self.assert_workflow_status(
-            res_id, ObjectVersion.FINAL, WorkflowStatus.COMPLETED
+            res_id, ObjectVersion.COMPLETED, WorkflowStatus.COMPLETED
         )
 
         # Discard changes - state of resource changed (no longer a valid

--- a/zenodo/modules/deposit/upgrades/deposit_2014_05_06_workflow_status_fix.py
+++ b/zenodo/modules/deposit/upgrades/deposit_2014_05_06_workflow_status_fix.py
@@ -100,18 +100,18 @@ def do_upgrade():
                     del sip.metadata[k]
             d.run_workflow(headless=True)
         elif is_done(d):
-            if o.version != ObjectVersion.FINAL or o.workflow.status != WorkflowStatus.COMPLETED:
+            if o.version != ObjectVersion.COMPLETED or o.workflow.status != WorkflowStatus.COMPLETED:
                 if o.version == ObjectVersion.HALTED and o.workflow.status == ObjectVersion.HALTED:
                     warn(o, 'DONE', "wf status %s -> %s" % (o.workflow.status, WorkflowStatus.COMPLETED))
-                    warn(o, 'DONE', "obj version %s -> %s" % (o.version, ObjectVersion.FINAL))
+                    warn(o, 'DONE', "obj version %s -> %s" % (o.version, ObjectVersion.COMPLETED))
                     o.workflow.status = WorkflowStatus.COMPLETED
-                    o.version = ObjectVersion.FINAL
-                elif o.version == ObjectVersion.FINAL and o.workflow.status == 5:
+                    o.version = ObjectVersion.COMPLETED
+                elif o.version == ObjectVersion.COMPLETED and o.workflow.status == 5:
                     warn(o, 'DONE', "wf status %s -> %s" % (o.workflow.status, WorkflowStatus.COMPLETED))
                     o.workflow.status = WorkflowStatus.COMPLETED
                 elif o.version == ObjectVersion.HALTED and o.workflow.status == WorkflowStatus.COMPLETED:
-                    warn(o, 'DONE', "obj version %s -> %s" % (o.version, ObjectVersion.FINAL))
-                    o.version = ObjectVersion.FINAL
+                    warn(o, 'DONE', "obj version %s -> %s" % (o.version, ObjectVersion.COMPLETED))
+                    o.version = ObjectVersion.COMPLETED
                 else:
                     warn(o, 'DONE', "Unmatched version %s status %s" % (o.version, o.workflow.status if o.workflow else None))
             else:


### PR DESCRIPTION
* Rename `ObjectVersion` FINAL to COMPLETED to comply with
  the changes introduced in inveniosoftware/invenio#2567

~~Note: The aforementioned changes are not yet merged, but this should be safe to merge since FINAL will continue being supported for some time.~~