### PR TITLE
base: alternate identifiers field

### DIFF
--- a/zenodo/base/format_templates/DataCite.xsl
+++ b/zenodo/base/format_templates/DataCite.xsl
@@ -50,12 +50,14 @@ exclude-result-prefixes="marc fn dc invenio">
         <xsl:choose>
             <xsl:when test="datafield[@tag=024 and @ind1=7]">
                 <xsl:for-each select="datafield[@tag=024 and @ind1=7]">
-                    <identifier>
-                        <xsl:attribute name="identifierType">
-                            <xsl:value-of select="subfield[@code='2']"/>
-                     </xsl:attribute>
-                        <xsl:value-of select="subfield[@code='a']"/>
-                    </identifier>
+                    <xsl:if test="subfield[@code='2'] = 'DOI'">
+                        <identifier>
+                            <xsl:attribute name="identifierType">
+                                <xsl:value-of select="subfield[@code='2']"/>
+                         </xsl:attribute>
+                            <xsl:value-of select="subfield[@code='a']"/>
+                        </identifier>
+                    </xsl:if>
                 </xsl:for-each>
             </xsl:when>
             <xsl:otherwise>

--- a/zenodo/base/format_templates/OAI_DataCite.xsl
+++ b/zenodo/base/format_templates/OAI_DataCite.xsl
@@ -43,7 +43,7 @@ exclude-result-prefixes="marc fn dc invenio">
             <oai_datacite xsi:schemaLocation="http://schema.datacite.org/oai/oai-1.0/ http://schema.datacite.org/oai/oai-1.0/oai.xsd">
                 <isReferenceQuality>true</isReferenceQuality>
                 <schemaVersion>2.2</schemaVersion>
-                <datacentreSymbol>DK.OPENAIRE</datacentreSymbol>
+                <datacentreSymbol>CERN.ZENODO</datacentreSymbol>
                 <payload>
                     <resource xmlns="http://datacite.org/schema/kernel-2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-2.2 http://schema.datacite.org/meta/kernel-2.2/metadata.xsd">
                     <xsl:apply-templates />
@@ -57,12 +57,14 @@ exclude-result-prefixes="marc fn dc invenio">
         <xsl:choose>
             <xsl:when test="datafield[@tag=024 and @ind1=7]">
                 <xsl:for-each select="datafield[@tag=024 and @ind1=7]">
-                    <identifier>
-                        <xsl:attribute name="identifierType">
-                            <xsl:value-of select="subfield[@code='2']"/>
-                     </xsl:attribute>
-                        <xsl:value-of select="subfield[@code='a']"/>
-                    </identifier>
+                    <xsl:if test="subfield[@code='2'] = 'DOI'">
+                        <identifier>
+                            <xsl:attribute name="identifierType">
+                                <xsl:value-of select="subfield[@code='2']"/>
+                         </xsl:attribute>
+                            <xsl:value-of select="subfield[@code='a']"/>
+                        </identifier>
+                    </xsl:if>
                 </xsl:for-each>
             </xsl:when>
             <xsl:otherwise>

--- a/zenodo/base/recordext/fields/zenodo.cfg
+++ b/zenodo/base/recordext/fields/zenodo.cfg
@@ -262,6 +262,17 @@ related_identifiers:
         json_for_marc(), {"773__a": "identifier", "773__n": "scheme", "773__i": "relation"}
         json_for_form(), {"related_identifiers": "[{'relation': value['relation'], 'scheme': value['scheme'], 'identifier': value['identifier']}]"}
 
+
+alternate_identifiers:
+    schema:
+        {'alternate_identifiers': {'type': 'list', 'force': True}}
+    creator:
+        @only_if_master_value((value['2'] or '').upper() != 'DOI')
+        marc, "0247_", {'identifier':value['a'], 'scheme': value['2']}
+    producer:
+        json_for_marc(), {"0247_a": "identifier", "0247_2": "scheme"}
+        json_for_form(), {"related_identifiers": "[{'relation': str('isAlternativeIdentifier'), 'scheme': value['scheme'], 'identifier': value['identifier']}]"}
+
 #
 # Journal
 #

--- a/zenodo/base/templates/format/record/Default_HTML_info.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_info.tpl
@@ -38,7 +38,16 @@
         {% if related_url %}<a href="{{related_id|pid_url}}">{{related_id.identifier}}</a>{% else %}<i>{{related_id.identifier}}</i> ({{related_id.scheme|upper}}){% endif %}{% if not loop.last %}, {% endif %}
     {%- endfor %}
     {%- endfor %}
-
+    {%- for alternateid in record.alternate_identifiers %}
+    {%- set alternate_url = alternateid|pid_url -%}
+    {%- if loop.first %}<dt>Alternate identifiers:</dt><dd>{% endif %}
+        {%- if alternate_url -%}
+            <a href="{{alternate_url}}">{{alternateid.scheme}}:{{alternateid.identifier}}</a>
+        {%- else -%}
+            {{alternateid.scheme}}:{{alternateid.identifier}}
+        {%- endif -%}
+    {%- if loop.last %}</dd>{% endif %}
+    {%- endfor %}
     {{ bfe_appears_in_collections(bfo, prefix='<dt>Collections:</dt><dd>', suffix='</dd>') }}
     {{ bfe_openaire_license(bfo, prefix='<dt>License (for files):</dt><dd>', suffix='</dd>') }}
     {% if bfo.field('8560_y') %}

--- a/zenodo/base/templates/zenodo/api.html
+++ b/zenodo/base/templates/zenodo/api.html
@@ -1760,7 +1760,7 @@ r = requests.post("{{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234/a
     <td><p>Persistent identifiers of related publications and datasets. Supported identifiers include: DOI, Handle, ARK, PURL, ISSN, ISBN, PubMed ID, PubMed Central ID, ADS Bibliographic Code, arXiv, Life Science Identifiers (LSID), EAN-13, ISTC, URNs and URLs. Each array element is an object with the attributes:</p>
     <ul>
       <li><code>identifier</code>: The persistent identifier</li>
-      <li><code>relation</code>: Relationship. Controlled vocabulary (<code>isCitedBy</code>, <code>cites</code>, <code>isSupplementTo</code>, <code>isSupplementedBy</code>, <code>isNewVersionOf</code>, <code>isPreviousVersionOf</code>, <code>isIdenticalTo</code>, <code>isPartOf</code>, <code>hasPart</code>).</li>
+      <li><code>relation</code>: Relationship. Controlled vocabulary (<code>isCitedBy</code>, <code>cites</code>, <code>isSupplementTo</code>, <code>isSupplementedBy</code>, <code>isNewVersionOf</code>, <code>isPreviousVersionOf</code>, <code>isPartOf</code>, <code>hasPart</code>, <code>isIdenticalTo</code>, <code>isAlternateIdentifier</code>).</li>
     </ul>
     <p>Example:</p>
     <pre>[
@@ -1980,6 +1980,10 @@ r = requests.post("{{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234/a
 
 <h2 id="restapi-changes">Changes</h2>
 <dl>
+<dt>2014-12-20</dt>
+<dd><p>Added new relationship <code>isAlternateIdentifier</code> in subfield <code>relation</code> to <code>related_identifiers</code> in deposition metadata.</p></dd>
+<dt>2014-12-10</dt>
+<dd><p>Added new relationships <code>hasPart</code>, <code>isPartOf</code> &amp; <code>isIdenticalTo</code> in subfield <code>relation</code> to <code>related_identifiers</code> in deposition metadata.</p></dd>
 <dt>2014-11-20</dt>
 <dd><p>Added new optional subfield <code>orcid</code> to <code>creators</code> in deposition metadata.</p></dd>
 <dt>2014-10-21</dt>

--- a/zenodo/base/testsuite/test_jsonext.py
+++ b/zenodo/base/testsuite/test_jsonext.py
@@ -35,6 +35,14 @@ test_marc = """<record>
   <datafield tag="520" ind1=" " ind2=" ">
     <subfield code="a">Test Description</subfield>
   </datafield>
+  <datafield tag="024" ind1="7" ind2=" ">
+    <subfield code="2">lsid</subfield>
+    <subfield code="a">urn:lsid:ubio.org:namebank:11815</subfield>
+  </datafield>
+  <datafield tag="024" ind1="7" ind2=" ">
+    <subfield code="2">ads</subfield>
+    <subfield code="a">2011ApJS..192...18K</subfield>
+  </datafield>
   <datafield tag="711" ind1=" " ind2=" ">
     <subfield code="c">Harvard-Smithsonian Center for Astrophysics</subfield>
     <subfield code="a">The 13th Biennial HITRAN Conference</subfield>
@@ -185,10 +193,17 @@ test_form_json = {
     'publication_type': 'book',
     'recid': 1,
     'related_identifiers': [
+        {'identifier': 'urn:lsid:ubio.org:namebank:11815',
+         'relation': 'isAlternativeIdentifier',
+         'scheme': 'lsid'},
+        {'identifier': '2011ApJS..192...18K',
+         'relation': 'isAlternativeIdentifier',
+         'scheme': 'ads'},
         {'identifier': '10.1234/foo.bar',
          'relation': 'cites',
          'scheme': 'doi'},
-        {'identifier': '1234.4321', 'relation': 'cites', 'scheme': 'arxiv'}],
+        {'identifier': '1234.4321', 'relation': 'cites', 'scheme': 'arxiv'},
+    ],
     'title': 'Test title',
     'upload_type': 'publication',
     'references': [
@@ -248,6 +263,12 @@ test_record = dict(
             "scheme": "doi", "relation": "cites"},
         {"identifier": "1234.4321", "scheme":
             "arxiv", "relation": "cites"},
+    ],
+    alternate_identifiers=[
+        {"identifier": "urn:lsid:ubio.org:namebank:11815",
+            "scheme": "lsid", },
+        {"identifier": "2011ApJS..192...18K", "scheme":
+            "ads", },
     ],
     meetings={
         'title': 'The 13th Biennial HITRAN Conference',

--- a/zenodo/modules/deposit/forms.py
+++ b/zenodo/modules/deposit/forms.py
@@ -187,9 +187,10 @@ class RelatedIdentifierForm(WebDepositForm):
             ('isSupplementedBy', 'is a supplement to this upload'),
             ('isNewVersionOf', 'is previous version of this upload'),
             ('isPreviousVersionOf', 'is new version of this upload'),
-            ('isIdenticalTo', 'is identical to upload'),
             ('isPartOf', 'has this upload as part'),
             ('hasPart', 'is part of this upload'),
+            ('isIdenticalTo', 'is identical to upload'),
+            ('isAlternativeIdentifier', 'is alternate identifier'),
         ],
         default='isSupplementTo',
         widget_classes='form-control',
@@ -807,7 +808,7 @@ class ZenodoForm(WebDepositForm):
             'indication': 'recommended',
             'description': '%s is integrated into reporting lines for research funded by the European Commission via OpenAIRE (http://www.openaire.eu). Specify grants which have funded your research, and we will let your funding agency know!' % CFG_SITE_NAME,
         }),
-        ('Related datasets/publications', [
+        ('Related/alternate identifiers', [
             'related_identifiers',
         ], {
             'classes': '',

--- a/zenodo/modules/deposit/testsuite/test_zenodo_api.py
+++ b/zenodo/modules/deposit/testsuite/test_zenodo_api.py
@@ -622,6 +622,9 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
                 related_identifiers=[
                     dict(identifier='10.1234/foo.bar2', relation='isCitedBy'),
                     dict(identifier='10.1234/foo.bar3', relation='cites'),
+                    dict(
+                        identifier='2011ApJS..192...18K',
+                        relation='isAlternativeIdentifier'),
                 ],
                 thesis_supervisors=[
                     dict(name="Doe Sr., John", affiliation="Atlantis"),
@@ -687,6 +690,9 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
                 publication_date="2013-09-12",
                 publication_type="book",
                 related_identifiers=[
+                    dict(
+                        identifier='2011ApJS..192...18K',
+                        relation='isAlternativeIdentifier'),
                     dict(identifier='10.1234/foo.bar2', relation='isCitedBy'),
                     dict(identifier='10.1234/foo.bar3', relation='cites'),
                 ],
@@ -1202,6 +1208,9 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
                 partof_title="Some part of title",
                 publication_type="book",
                 related_identifiers=[
+                    dict(
+                        identifier='2011ApJS..192...18K',
+                        relation='isAlternativeIdentifier'),
                     dict(identifier='10.1234/foo.bar2', relation='isCitedBy'),
                     dict(identifier='10.1234/foo.bar3', relation='cites'),
                 ],
@@ -1447,6 +1456,7 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
         self.assertEqual(record.get('license'), None)
         self.assertEqual(record['owner']['deposition_id'], str(res_id))
         self.assertEqual(record.get('url'), None)
+        self.assertEqual(record['alternate_identifiers'][0]['scheme'], "ads")
 
         # Communities
         self.assertEqual(record.get('communities'), ['zenodo'])
@@ -1489,6 +1499,12 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
         self.assertEqual(
             response.json['metadata']['title'],
             "To be discarded"
+        )
+        # Test if alternate identifiers was loaded correctly.
+        self.assertEqual(
+            response.json['metadata']['related_identifiers'][0],
+            {u'scheme': u'ads', u'identifier': u'2011ApJS..192...18K',
+             u'relation': u'isAlternativeIdentifier'},
         )
 
         # Discard changes.

--- a/zenodo/modules/deposit/workflows/upload.py
+++ b/zenodo/modules/deposit/workflows/upload.py
@@ -165,6 +165,25 @@ def process_recjson(deposition, recjson):
         # Happens on re-run
         pass
 
+    # =============================
+    # Related/alternate identifiers
+    # =============================
+    if recjson.get('related_identifiers', []):
+        related_identifiers = recjson.get('related_identifiers', [])
+
+        recjson['related_identifiers'] = filter(
+            lambda x: x.get('relation', '') != 'isAlternativeIdentifier',
+            related_identifiers
+        )
+
+        recjson['alternate_identifiers'] = map(
+            lambda x: {'scheme': x['scheme'], 'identifier': x['identifier']},
+            filter(
+                lambda x: x.get('relation', '') == 'isAlternativeIdentifier',
+                related_identifiers
+            )
+        )
+
     # =================
     # License
     # =================


### PR DESCRIPTION
- Adds new field alternate identifiers to data model, and integrates the field
  with related identifiers field in deposit model.
- Adds support in DataCite metadata for links to files when record is open
  access.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch

<!---
@huboard:{"order":2.0,"milestone_order":95,"custom_state":""}
-->
