### PR TITLE
base: remove whitespace on frontpage

### DIFF
--- a/zenodo/base/static/less/zenodo.less
+++ b/zenodo/base/static/less/zenodo.less
@@ -550,13 +550,12 @@ body {
 }
 
 /* Set the fixed height of the footer here */
-#push,
-#footer {
-  height: 220px;
+#push {
+  height: 130px;
 }
 
-#push {
-  margin-top: 60px;
+#footer {
+  height: 220px;
 }
 
 #footer {


### PR DESCRIPTION
* Removes margin-top from div#push and reduce its height. (closes #75)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>