### PR TITLE
global: standardisation on "Zenodo" service name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ======
-ZENODO
+Zenodo
 ======
 
 .. image:: https://api.shippable.com/projects/5477dd61d46935d5fbbed43b/badge?branchName=master
@@ -7,12 +7,12 @@ ZENODO
 .. image:: https://coveralls.io/repos/zenodo/zenodo/badge.png?branch=master
     :target: https://coveralls.io/r/zenodo/zenodo
 
-ZENODO is an open dependable home for the long-tail of science, enabling researchers to share and preserve any research outputs in any size, any format and from any science.
+Zenodo is an open dependable home for the long-tail of science, enabling researchers to share and preserve any research outputs in any size, any format and from any science.
 
 
 Powered by Invenio
 -------------------
-ZENODO is a small layer on top of `Invenio <http://invenio-software.org>`, a ​free software suite enabling you to run your own ​digital library or document repository on the web.
+Zenodo is a small layer on top of `Invenio <http://invenio-software.org>`, a ​free software suite enabling you to run your own ​digital library or document repository on the web.
 
 
 Installation
@@ -35,14 +35,14 @@ or (to also show test coverage) ::
 
 License
 =======
-Copyright (C) 2009-2014 CERN.
+Copyright (C) 2009-2015 CERN.
 
-ZENODO (TM) and the ZENODO logo are trademarked by CERN and are not covered by the license below. Thus if you instantiate the software you must change the branding to your own.
+Zenodo (TM) and the Zenodo logo are trademarked by CERN and are not covered by the license below. Thus if you instantiate the software you must change the branding to your own.
 
-ZENODO is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+Zenodo is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 
-ZENODO is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+Zenodo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along with ZENODO; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+You should have received a copy of the GNU General Public License along with Zenodo; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 In applying this licence, CERN does not waive the privileges and immunities granted to it by virtue of its status as an Intergovernmental Organization or submit itself to any jurisdiction.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,18 +1,18 @@
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2014 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/base-pinned.requirements.txt
+++ b/base-pinned.requirements.txt
@@ -5,7 +5,7 @@
 #
 #
 # (at your option) any later version.
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # Copyright (C) 2014 CERN.
 # GNU General Public License for more details.
@@ -20,11 +20,11 @@
 # Requirements in this file cannot easily be upgraded due to problems in
 # the Free Software Foundation, either version 3 of the License, or
 # the problem has been fixed in the newer version.
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # This means that when running ``pip-review`` these packages should in general
 # You should have received a copy of the GNU General Public License
-# ZENODO is distributed in the hope that it will be useful,
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is distributed in the hope that it will be useful,
+# Zenodo is free software: you can redistribute it and/or modify
 
 ## Pinned base requirements
 https://www.reportlab.com/ftp/pyRXP-1.16-daily-unix.tar.gz#egg=pyRXP

--- a/base.requirements.txt
+++ b/base.requirements.txt
@@ -1,18 +1,18 @@
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2014 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/dev.requirements.txt
+++ b/dev.requirements.txt
@@ -1,18 +1,18 @@
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2014 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -85,17 +85,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/ZENODO.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/Zenodo.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/ZENODO.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Zenodo.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/ZENODO"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/ZENODO"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/Zenodo"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/Zenodo"
 	@echo "# devhelp"
 
 epub:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# ZENODO documentation build configuration file, created by
+# Zenodo documentation build configuration file, created by
 # sphinx-quickstart on Thu Nov 21 14:30:47 2013.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -59,7 +59,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'ZENODO'
+project = u'Zenodo'
 copyright = u'{0}, CERN'.format(datetime.now().year)
 
 # The version info for the project you're documenting, acts as replacement for
@@ -187,7 +187,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ZENODOdoc'
+htmlhelp_basename = 'Zenododoc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -206,7 +206,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'ZENODO.tex', u'ZENODO Documentation',
+  ('index', 'Zenodo.tex', u'Zenodo Documentation',
    u'CERN', 'manual'),
 ]
 
@@ -236,7 +236,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'zenodo', u'ZENODO Documentation',
+    ('index', 'zenodo', u'Zenodo Documentation',
      [u'CERN'], 1)
 ]
 
@@ -250,8 +250,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'ZENODO', u'ZENODO Documentation',
-   u'CERN', 'ZENODO', 'One line description of project.',
+  ('index', 'Zenodo', u'Zenodo Documentation',
+   u'CERN', 'Zenodo', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,18 +7,18 @@ Zenodo
    :width: 300
    :class: pull-right
 
-ZENODO is an open dependable home for the long-tail of science, enabling
+Zenodo is an open dependable home for the long-tail of science, enabling
 researchers to share and preserve any research outputs in any size, any
 format and from any science.
 
 **Powered by Invenio**
 
-ZENODO is a small layer on top of `Invenio <http://invenio-software.org>`_, a
+Zenodo is a small layer on top of `Invenio <http://invenio-software.org>`_, a
 ​free software suite enabling you to run your own ​digital library or document
 repository on the web.
 
 .. note::
-   ZENODO (R) and the ZENODO logo are trademarked by CERN and are not covered
+   Zenodo (R) and the Zenodo logo are trademarked by CERN and are not covered
    by the GPLv3 license. Thus, if you instantiate Zenodo on your own servers you
    must change the branding to your own.
 

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -2,24 +2,24 @@ License
 =======
 
 .. note::
-   ZENODO source code is licensed under GNU General Public License version 3. This
-   does not apply to the name ZENODO (TM) and the ZENODO logo which are trademarked
+   Zenodo source code is licensed under GNU General Public License version 3. This
+   does not apply to the name Zenodo (TM) and the Zenodo logo which are trademarked
    by CERN. Thus if you instantiate the software you must change the branding to your own.
 
-Copyright (C) 2009-2014 CERN.
+Copyright (C) 2009-2015 CERN.
 
-ZENODO is free software: you can redistribute it and/or modify
+Zenodo is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-ZENODO is distributed in the hope that it will be useful,
+Zenodo is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 
 In applying this licence, CERN does not waive the privileges and immunities
 granted to it by virtue of its status as an Intergovernmental Organization

--- a/requirements.master.txt
+++ b/requirements.master.txt
@@ -1,18 +1,18 @@
-# This file is part of ZENODO.
-# Copyright (C) 2014 CERN.
+# This file is part of Zenodo.
+# Copyright (C) 2014, 2015 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
@@ -25,6 +25,6 @@
 ## Requirements
 -r base.requirements.txt
 
-## Invenio and ZENODO
+## Invenio and Zenodo
 -e git+https://github.com/zenodo/invenio.git@pu-zenodo#egg=Invenio
 -e .

--- a/requirements.production.txt
+++ b/requirements.production.txt
@@ -1,18 +1,18 @@
-# This file is part of ZENODO.
-# Copyright (C) 2014 CERN.
+# This file is part of Zenodo.
+# Copyright (C) 2014, 2015 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
@@ -25,6 +25,6 @@
 ## Requirements
 -r base.requirements.txt
 
-## Invenio and ZENODO
+## Invenio and Zenodo
 -e git+https://github.com/zenodo/invenio.git@production#egg=Invenio
 -e .

--- a/requirements.qa.txt
+++ b/requirements.qa.txt
@@ -1,18 +1,18 @@
-# This file is part of ZENODO.
-# Copyright (C) 2014 CERN.
+# This file is part of Zenodo.
+# Copyright (C) 2014, 2015 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
@@ -25,6 +25,6 @@
 ## Requirements
 -r base.requirements.txt
 
-## Invenio and ZENODO
+## Invenio and Zenodo
 -e git+https://github.com/zenodo/invenio.git@qa#egg=Invenio
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
-# This file is part of ZENODO.
-# Copyright (C) 2014 CERN.
+# This file is part of Zenodo.
+# Copyright (C) 2014, 2015 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
@@ -25,6 +25,6 @@
 ## Requirements
 -r dev.requirements.txt
 
-## Invenio and ZENODO
+## Invenio and Zenodo
 -e git+https://github.com/zenodo/invenio@pu-zenodo#egg=Invenio
 -e .[development]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,19 +1,19 @@
 ##
-## This file is part of ZENODO
+## This file is part of Zenodo
 ## Copyright (C) 2013 CERN.
 ##
-## ZENODO is free software; you can redistribute it and/or
+## Zenodo is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
 ## published by the Free Software Foundation; either version 2 of the
 ## License, or (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful, but
+## Zenodo is distributed in the hope that it will be useful, but
 ## WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ## General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO; if not, write to the Free Software Foundation,
+## along with Zenodo; if not, write to the Free Software Foundation,
 ## Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,27 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
-## Copyright (C) 2012, 2013, 2014 CERN.
+## This file is part of Zenodo.
+## Copyright (C) 2012, 2013, 2014, 2015 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
 ## or submit itself to any jurisdiction.
 
 """
-ZENODO - Research. Shared.
+Zenodo - Research. Shared.
 
 Links
 -----

--- a/test.requirements.txt
+++ b/test.requirements.txt
@@ -1,18 +1,18 @@
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2014 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/traviscache.py
+++ b/traviscache.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/__init__.py
+++ b/zenodo/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/__init__.py
+++ b/zenodo/base/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/bundles.py
+++ b/zenodo/base/bundles.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/facets/facet_access_rights.py
+++ b/zenodo/base/facets/facet_access_rights.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/facets/facet_project.py
+++ b/zenodo/base/facets/facet_project.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/__init__.py
+++ b/zenodo/base/format_elements/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_appears_in_collections.py
+++ b/zenodo/base/format_elements/bfe_appears_in_collections.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_edit_files.py
+++ b/zenodo/base/format_elements/bfe_edit_files.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_edit_record.py
+++ b/zenodo/base/format_elements/bfe_edit_record.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_files.py
+++ b/zenodo/base/format_elements/bfe_files.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_icon.py
+++ b/zenodo/base/format_elements/bfe_icon.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_jinja.py
+++ b/zenodo/base/format_elements/bfe_jinja.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_notes.py
+++ b/zenodo/base/format_elements/bfe_notes.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_access_rights.py
+++ b/zenodo/base/format_elements/bfe_openaire_access_rights.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_altmetric.py
+++ b/zenodo/base/format_elements/bfe_openaire_altmetric.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_authors.py
+++ b/zenodo/base/format_elements/bfe_openaire_authors.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_license.py
+++ b/zenodo/base/format_elements/bfe_openaire_license.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_meeting.py
+++ b/zenodo/base/format_elements/bfe_openaire_meeting.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_published_in_book.py
+++ b/zenodo/base/format_elements/bfe_openaire_published_in_book.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_pubtype.py
+++ b/zenodo/base/format_elements/bfe_openaire_pubtype.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
-## Copyright (C) 2012, 2013 CERN.
+## This file is part of Zenodo.
+## Copyright (C) 2012, 2013, 2015 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
@@ -32,7 +32,7 @@ def format_element(bfo, as_label=False, brief=False):
     # type in subfield a is used. Subfield b denotes a subtype.
     #
     # Other non-publication type 980 entries include user collection
-    # identifiers, and ZENODO specific identifiers like "curated".
+    # identifiers, and Zenodo specific identifiers like "curated".
 
     CFG_OPENAIRE_PUBTYPE_MAP = current_app.config['CFG_OPENAIRE_PUBTYPE_MAP']
     for c in collections:

--- a/zenodo/base/format_elements/bfe_openaire_related_dois.py
+++ b/zenodo/base/format_elements/bfe_openaire_related_dois.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_university.py
+++ b/zenodo/base/format_elements/bfe_openaire_university.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_user_email.py
+++ b/zenodo/base/format_elements/bfe_openaire_user_email.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_openaire_user_fullname.py
+++ b/zenodo/base/format_elements/bfe_openaire_user_fullname.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_qrcode.py
+++ b/zenodo/base/format_elements/bfe_qrcode.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_record_url.py
+++ b/zenodo/base/format_elements/bfe_record_url.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/format_elements/bfe_sword_push.py
+++ b/zenodo/base/format_elements/bfe_sword_push.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/jsonext/__init__.py
+++ b/zenodo/base/jsonext/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/jsonext/producers/__init__.py
+++ b/zenodo/base/jsonext/producers/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/jsonext/producers/json_for_ld.py
+++ b/zenodo/base/jsonext/producers/json_for_ld.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/output_formats/__init__.py
+++ b/zenodo/base/output_formats/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/rankext/__init__.py
+++ b/zenodo/base/rankext/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/rankext/configuration/download_users.cfg
+++ b/zenodo/base/rankext/configuration/download_users.cfg
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/recordext/__init__.py
+++ b/zenodo/base/recordext/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/recordext/fields/zenodo.cfg
+++ b/zenodo/base/recordext/fields/zenodo.cfg
@@ -1,18 +1,18 @@
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/recordext/functions/__init__.py
+++ b/zenodo/base/recordext/functions/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/sorterext/__init__.py
+++ b/zenodo/base/sorterext/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/js/settings.js
+++ b/zenodo/base/static/js/settings.js
@@ -1,19 +1,19 @@
 /*
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/js/zenodo/init.js
+++ b/zenodo/base/static/js/zenodo/init.js
@@ -1,19 +1,19 @@
 /*
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/js/zenodo/templates/ajaxmsg.mustache
+++ b/zenodo/base/static/js/zenodo/templates/ajaxmsg.mustache
@@ -1,19 +1,19 @@
 {{!
-  This file is part of ZENODO.
+  This file is part of Zenodo.
   Copyright (C) 2014 CERN.
 
-  ZENODO is free software: you can redistribute it and/or modify
+  Zenodo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ZENODO is distributed in the hope that it will be useful,
+  Zenodo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+  along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 
   In applying this licence, CERN does not waive the privileges and immunities
   granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/js/zenodo/templates/alert.mustache
+++ b/zenodo/base/static/js/zenodo/templates/alert.mustache
@@ -1,19 +1,19 @@
 {{!
-  This file is part of ZENODO.
+  This file is part of Zenodo.
   Copyright (C) 2014 CERN.
 
-  ZENODO is free software: you can redistribute it and/or modify
+  Zenodo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ZENODO is distributed in the hope that it will be useful,
+  Zenodo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+  along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 
   In applying this licence, CERN does not waive the privileges and immunities
   granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/js/zenodo/templates/collections.mustache
+++ b/zenodo/base/static/js/zenodo/templates/collections.mustache
@@ -1,19 +1,19 @@
 {{!
-  This file is part of ZENODO.
+  This file is part of Zenodo.
   Copyright (C) 2014 CERN.
 
-  ZENODO is free software: you can redistribute it and/or modify
+  Zenodo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ZENODO is distributed in the hope that it will be useful,
+  Zenodo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+  along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 
   In applying this licence, CERN does not waive the privileges and immunities
   granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/js/zenodo/templates/funding_source.mustache
+++ b/zenodo/base/static/js/zenodo/templates/funding_source.mustache
@@ -1,19 +1,19 @@
 {{!
-  This file is part of ZENODO.
+  This file is part of Zenodo.
   Copyright (C) 2014 CERN.
 
-  ZENODO is free software: you can redistribute it and/or modify
+  Zenodo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ZENODO is distributed in the hope that it will be useful,
+  Zenodo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+  along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 
   In applying this licence, CERN does not waive the privileges and immunities
   granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/js/zenodo/templates/tag.mustache
+++ b/zenodo/base/static/js/zenodo/templates/tag.mustache
@@ -1,19 +1,19 @@
 {{!
-  This file is part of ZENODO.
+  This file is part of Zenodo.
   Copyright (C) 2014 CERN.
 
-  ZENODO is free software: you can redistribute it and/or modify
+  Zenodo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ZENODO is distributed in the hope that it will be useful,
+  Zenodo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+  along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 
   In applying this licence, CERN does not waive the privileges and immunities
   granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/js/zenodo/zenodo.js
+++ b/zenodo/base/static/js/zenodo/zenodo.js
@@ -1,19 +1,19 @@
 /*
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/less/zenodo-variables.less
+++ b/zenodo/base/static/less/zenodo-variables.less
@@ -1,21 +1,21 @@
 /**
  * -*- mode: text; coding: utf-8; -*-
  *
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/static/less/zenodo.less
+++ b/zenodo/base/static/less/zenodo.less
@@ -1,21 +1,21 @@
 /**
  * -*- mode: text; coding: utf-8; -*-
  *
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/templates/format/record/Default_HTML_brief.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_brief.tpl
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/templates/format/record/Default_HTML_detailed.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_detailed.tpl
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software; you can redistribute it and/or
+## Zenodo is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
 ## published by the Free Software Foundation; either version 2 of the
 ## License, or (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful, but
+## Zenodo is distributed in the hope that it will be useful, but
 ## WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ## General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO; if not, write to the Free Software Foundation, Inc.,
+## along with Zenodo; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities

--- a/zenodo/base/templates/page.html
+++ b/zenodo/base/templates/page.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software; you can redistribute it and/or
+## Zenodo is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
 ## published by the Free Software Foundation; either version 2 of the
 ## License, or (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful, but
+## Zenodo is distributed in the hope that it will be useful, but
 ## WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ## General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO; if not, write to the Free Software Foundation, Inc.,
+## along with Zenodo; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities

--- a/zenodo/base/templates/search/index.html
+++ b/zenodo/base/templates/search/index.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/templates/zenodo/api.html
+++ b/zenodo/base/templates/zenodo/api.html
@@ -1,6 +1,6 @@
 {#
 ## This file is part of Invenio.
-## Copyright (C) 2013, 2014 CERN.
+## Copyright (C) 2013, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -146,7 +146,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 
 <li><p>Last thing missing, is just to add some metadata:</p>
 <pre>
->>> data = {"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "ZENODO"}]}}
+>>> data = {"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "Zenodo"}]}}
 >>> r = requests.put("{{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/%s?access_token=ACCESS_TOKEN" % deposition_id, data=json.dumps(data), headers=headers)
 >>> r.status_code
 200
@@ -179,7 +179,7 @@ The REST API is versioned. We strive not to make backward incompatible changes t
 
 <p><strong>Acquiring a personal access token</strong>
 <ol>
-<li><a href="{{url_for('youraccount.register')}}">Register</a> for a ZENODO account if you don't already have one.</li>
+<li><a href="{{url_for('youraccount.register')}}">Register</a> for a Zenodo account if you don't already have one.</li>
 <li>Go to your <a href="{{url_for('oauth2server_settings.index')}}">Applications</a>, to <a href="{{url_for('oauth2server_settings.token_new')}}">create a new token</a>.</li>
 <li>Select the OAuth scopes you need (for the quick start tutorial you need <code>deposit:write</code> and <code>deposit:actions</code>).</li>
 </ol>
@@ -483,7 +483,7 @@ print response.json()
 
 <em>or</em>
 
-$ curl -i -H "Content-Type: application/json" -X POST --data '{"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "ZENODO"}]}}' {{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/?access_token=ACCESS_TOKEN</pre>
+$ curl -i -H "Content-Type: application/json" -X POST --data '{"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "Zenodo"}]}}' {{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/?access_token=ACCESS_TOKEN</pre>
     </div>
     <div class="tab-pane" id="python-d-create">
       <pre>import json
@@ -495,7 +495,7 @@ r = requests.post(url, data="{}", headers=headers)
 
 <span class="muted"># or</span>
 
-data = {"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "ZENODO"}]}}
+data = {"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "Zenodo"}]}}
 r = requests.post(url, data=json.dumps(data), headers=headers)</pre>
     </div>
   </div>
@@ -645,7 +645,7 @@ r = requests.get("{{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234?ac
   </ul>
   <div class="tab-content">
     <div class="tab-pane active" id="curl-d-put">
-      <pre>$ curl -i -H "Content-Type: application/json" -X PUT --data '{"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "ZENODO"}]}}' {{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234?access_token=ACCESS_TOKEN</pre>
+      <pre>$ curl -i -H "Content-Type: application/json" -X PUT --data '{"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "Zenodo"}]}}' {{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234?access_token=ACCESS_TOKEN</pre>
     </div>
     <div class="tab-pane" id="python-d-put">
       <pre>import json
@@ -653,7 +653,7 @@ import requests
 
 url = "{{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234?access_token=ACCESS_TOKEN"
 headers = {"Content-Type": "application/json"}
-data = {"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "ZENODO"}]}}
+data = {"metadata": {"title": "My first upload", "upload_type": "poster", "description": "This is my first upload", "creators": [{"name": "Doe, John", "affiliation": "Zenodo"}]}}
 
 r = requests.put(url, data=json.dumps(data), headers=headers)</pre>
     </div>
@@ -1697,8 +1697,8 @@ r = requests.post("{{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234/a
       <li><code>orcid</code>: ORCID identifier of creator (optional).</li>
     </ul>
     <p>Example:</p>
-    <pre>[{'name':'Doe, John', 'affiliation': 'ZENODO'},
-{'name':'Smith, Jane', 'affiliation': 'ZENODO'}]</pre></td>
+    <pre>[{'name':'Doe, John', 'affiliation': 'Zenodo'},
+{'name':'Smith, Jane', 'affiliation': 'Zenodo'}]</pre></td>
 </tr>
 <tr>
     <td><code>description</code></td>
@@ -2051,7 +2051,7 @@ Metadata for each record is available in several formats. The available formats 
 <p>We support both harvesting of the <em>entire repository</em> as well as <em>selective harvesting</em> of communities.</p>
 <dl>
 <dt><code>zenodo</code></dt>
-<dd><p>All of ZENODO</p><p><a href="view-source:{{config.CFG_SITE_SECURE_URL}}/oai2d?verb=ListRecords&metadataPrefix=oai_datacite&set=zenodo">See example</a></p></dd>
+<dd><p>All of Zenodo</p><p><a href="view-source:{{config.CFG_SITE_SECURE_URL}}/oai2d?verb=ListRecords&metadataPrefix=oai_datacite&set=zenodo">See example</a></p></dd>
 <dt><code>user-<em>&lt;identifier&gt;</em></code></dt>
 <dd><p>Community sets &mdash; allows selective harvesting of specific communities. Replace <code><em>&lt;identifier&gt;</em></code> with the community identifier. Alternatively each community provides a direct harvesting API link on their front-page, which includes the correct community identifier.</p><p><a href="view-source:{{config.CFG_SITE_SECURE_URL}}/oai2d?verb=ListRecords&metadataPrefix=oai_datacite&set=user-cfa">See example</a></p></dd>
 </dl>

--- a/zenodo/base/templates/zenodo/faq.html
+++ b/zenodo/base/templates/zenodo/faq.html
@@ -1,6 +1,6 @@
 {#
 ## This file is part of Invenio.
-## Copyright (C) 2012, 2014 CERN.
+## Copyright (C) 2012, 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -52,8 +52,8 @@
         </p>
     </li>
     <li>
-        <h5>What does it cost / Can we pay for ZENODO services? </h5>
-        <p>ZENODO is free for the long tail of Science. In order to offer services to the more resource hungry research, we will introduce a ceiling to the free slice and offer paid for slices above, according to the business model developed within the sustainability plan. If you can't wait but immediately want to explore these paid for options, please <a href="/contact">contact us</a> and we will look at interim measures with you.</p>
+        <h5>What does it cost / Can we pay for Zenodo services? </h5>
+        <p>Zenodo is free for the long tail of Science. In order to offer services to the more resource hungry research, we will introduce a ceiling to the free slice and offer paid for slices above, according to the business model developed within the sustainability plan. If you can't wait but immediately want to explore these paid for options, please <a href="/contact">contact us</a> and we will look at interim measures with you.</p>
     </li>
     <li>
         <h5>Really, who pays for this?</h5>

--- a/zenodo/base/templates/zenodo/policies.html
+++ b/zenodo/base/templates/zenodo/policies.html
@@ -1,6 +1,6 @@
 {#
 ## This file is part of Invenio.
-## Copyright (C) 2012 CERN.
+## Copyright (C) 2012, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -46,7 +46,7 @@ Records can be retracted from public view, however the data files and record is 
 <dd>2GB per file size constraint. Higher quotas per file can be requested. Quotas are likely to be introduced at a later stage. All data files are stored in CERN Data Centres, primarily Geneva, with replicas in Budapest. Data files are kept in multiple replicas in a distributed file system which is backed up to tape on a nightly basis.</dd>
 
 <dt>Data quality</dt>
-<dd>All information is provided “as-is” and the user shall hold ZENODO and information providers supplying data to ZENODO free and harmless in connection with the use of such information.</dd>
+<dd>All information is provided “as-is” and the user shall hold Zenodo and information providers supplying data to Zenodo free and harmless in connection with the use of such information.</dd>
 
 </dl>
 
@@ -66,7 +66,7 @@ Records can be retracted from public view, however the data files and record is 
 
 <dl>
 <dt>Metadata access</dt>
-<dd>ZENODO is provided free of charge for educational and informational use.
+<dd>Zenodo is provided free of charge for educational and informational use.
 Metadata is licensed under CC0, except for email addresses.</dd>
 
 <dt>Metadata reuse</dt>
@@ -105,8 +105,8 @@ All metadata is exported via OAI-PMH and can be harvested.</dd>
 <dd>Use and re-use is subject to the license under which the data objects were deposited.</dd>
 
 <dt>Tracking users and statistics</dt>
-<dd>ZENODO does not track, collect or retain personal information from users of ZENODO, except as otherwise provided herein. In order to enhance ZENODO and monitor traffic, non-personal information such as IP addresses and cookies may be tracked and retained, as well as log files shared in aggregation with other community services (in particular OpenAIREplus partners). User provided information, like corrections of metadata or paper claims, will be integrated into the database without displaying its source and may be shared with other services.
-ZENODO will take all reasonable measures to protect the privacy of its users and to resist service interruptions, intentional attacks, or other events that may compromise the security of the ZENODO website.</dd>
+<dd>Zenodo does not track, collect or retain personal information from users of Zenodo, except as otherwise provided herein. In order to enhance Zenodo and monitor traffic, non-personal information such as IP addresses and cookies may be tracked and retained, as well as log files shared in aggregation with other community services (in particular OpenAIREplus partners). User provided information, like corrections of metadata or paper claims, will be integrated into the database without displaying its source and may be shared with other services.
+Zenodo will take all reasonable measures to protect the privacy of its users and to resist service interruptions, intentional attacks, or other events that may compromise the security of the Zenodo website.</dd>
 </dl>
 
 <h4>Preservation of data</h4>
@@ -116,7 +116,7 @@ ZENODO will take all reasonable measures to protect the privacy of its users and
 <dd>Items will be retained for the lifetime of the repository.</dd>
 
 <dt>Functional preservation</dt>
-<dd>ZENODO makes no promises of usability and understandability of deposited objects over time.</dd>
+<dd>Zenodo makes no promises of usability and understandability of deposited objects over time.</dd>
 
 <dt>File preservation</dt>
 <dd>Data files and metadata is backed up on a nightly basis, as well as replicated in multiple copies in the online system.</dd>

--- a/zenodo/base/templates/zenodo/terms.html
+++ b/zenodo/base/templates/zenodo/terms.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/testsuite/test_jsonext.py
+++ b/zenodo/base/testsuite/test_jsonext.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
-## Copyright (C) 2014 CERN.
+## This file is part of Zenodo.
+## Copyright (C) 2014, 2015 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
@@ -70,10 +70,10 @@ test_marc = """<record>
     <subfield code="a">Title Grant</subfield>
   </datafield>
   <datafield tag="999" ind1="C" ind2="5">
-    <subfield code="x">Doe, John et al (2012). Some title. ZENODO. 10.5281/zenodo.12</subfield>
+    <subfield code="x">Doe, John et al (2012). Some title. Zenodo. 10.5281/zenodo.12</subfield>
   </datafield>
   <datafield tag="999" ind1="C" ind2="5">
-    <subfield code="x">Smith, Jane et al (2012). Some title. ZENODO. 10.5281/zenodo.34</subfield>
+    <subfield code="x">Smith, Jane et al (2012). Some title. Zenodo. 10.5281/zenodo.34</subfield>
   </datafield>
   <datafield tag="700" ind1=" " ind2=" ">
     <subfield code="u">CERN</subfield>
@@ -207,8 +207,8 @@ test_form_json = {
     'title': 'Test title',
     'upload_type': 'publication',
     'references': [
-        'Doe, John et al (2012). Some title. ZENODO. 10.5281/zenodo.12',
-        'Smith, Jane et al (2012). Some title. ZENODO. 10.5281/zenodo.34',
+        'Doe, John et al (2012). Some title. Zenodo. 10.5281/zenodo.12',
+        'Smith, Jane et al (2012). Some title. Zenodo. 10.5281/zenodo.34',
     ],
     'conference_title': 'The 13th Biennial HITRAN Conference',
     'conference_place': 'Harvard-Smithsonian Center for Astrophysics',
@@ -281,9 +281,9 @@ test_record = dict(
     altmetric_id="9876",
     preservation_score="100",
     references=[
-        {'raw_reference': 'Doe, John et al (2012). Some title. ZENODO. '
+        {'raw_reference': 'Doe, John et al (2012). Some title. Zenodo. '
                           '10.5281/zenodo.12'},
-        {'raw_reference': 'Smith, Jane et al (2012). Some title. ZENODO. '
+        {'raw_reference': 'Smith, Jane et al (2012). Some title. Zenodo. '
                           '10.5281/zenodo.34'},
     ]
 )

--- a/zenodo/base/testsuite/test_validate_datacite_xml.py
+++ b/zenodo/base/testsuite/test_validate_datacite_xml.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/base_2014_11_17_new_subtype_proposal.py
+++ b/zenodo/base/upgrades/base_2014_11_17_new_subtype_proposal.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_02_18_zenodo_data.py
+++ b/zenodo/base/upgrades/openaire_2013_02_18_zenodo_data.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_03_03_license_data.py
+++ b/zenodo/base/upgrades/openaire_2013_03_03_license_data.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_03_07_zenodo_collections.py
+++ b/zenodo/base/upgrades/openaire_2013_03_07_zenodo_collections.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_03_07_zenodo_migration.py
+++ b/zenodo/base/upgrades/openaire_2013_03_07_zenodo_migration.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_03_11_zenodo_user.py
+++ b/zenodo/base/upgrades/openaire_2013_03_11_zenodo_user.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_03_20_datacite_output_fmt.py
+++ b/zenodo/base/upgrades/openaire_2013_03_20_datacite_output_fmt.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_04_18_usercollection.py
+++ b/zenodo/base/upgrades/openaire_2013_04_18_usercollection.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_05_02_hbpro_hdcur_fmt.py
+++ b/zenodo/base/upgrades/openaire_2013_05_02_hbpro_hdcur_fmt.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_05_02_pidstore.py
+++ b/zenodo/base/upgrades/openaire_2013_05_02_pidstore.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_05_07_zenodo_usercollection.py
+++ b/zenodo/base/upgrades/openaire_2013_05_07_zenodo_usercollection.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_05_29_pidstore_refactor.py
+++ b/zenodo/base/upgrades/openaire_2013_05_29_pidstore_refactor.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_06_25_expjob_rename.py
+++ b/zenodo/base/upgrades/openaire_2013_06_25_expjob_rename.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_09_25_software_coll.py
+++ b/zenodo/base/upgrades/openaire_2013_09_25_software_coll.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_2013_10_11_webdeposit_migration.py
+++ b/zenodo/base/upgrades/openaire_2013_10_11_webdeposit_migration.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/openaire_release_initial.py
+++ b/zenodo/base/upgrades/openaire_release_initial.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/zenodo_2014_11_25_workflowobjectfix.py
+++ b/zenodo/base/upgrades/zenodo_2014_11_25_workflowobjectfix.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/base/upgrades/zenodo_2015_01_12_zenodo_service_name.py
+++ b/zenodo/base/upgrades/zenodo_2015_01_12_zenodo_service_name.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Zenodo.
+# Copyright (C) 2015 CERN.
+#
+# Zenodo is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Standardise on Zenodo collection names."""
+
+from sqlalchemy import *
+from invenio.legacy.dbquery import run_sql
+
+
+depends_on = [u'zenodo_2014_11_25_workflowobjectfix']
+
+
+def info():
+    return "Standardise on Zenodo collection names."
+
+
+def do_upgrade():
+    run_sql("UPDATE collection SET name='Zenodo' WHERE name='ZENODO'")
+    run_sql("UPDATE collectionname SET value='Zenodo' WHERE value='ZENODO'")
+    run_sql("UPDATE collectionname SET value='Provisional: Zenodo' WHERE value='Provisional: ZENODO'")
+    run_sql("UPDATE accARGUMENT SET value='Zenodo' WHERE value='ZENODO'")
+
+
+def estimate():
+    return 1

--- a/zenodo/base/views.py
+++ b/zenodo/base/views.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
-## Copyright (C) 2012, 2013, 2014 CERN.
+## This file is part of Zenodo.
+## Copyright (C) 2012, 2013, 2014, 2015 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
@@ -257,9 +257,9 @@ CFG_DATABASE_NAME = "zenodo"
 CFG_DATABASE_USER = "zenodo"
 
 # Name
-CFG_SITE_NAME = "ZENODO"
+CFG_SITE_NAME = "Zenodo"
 CFG_SITE_NAME_INTL = dict(
-    en="ZENODO",
+    en="Zenodo",
 )
 CFG_SITE_LANGS = ["en"]
 CFG_SITE_TAG = "LOCAL"

--- a/zenodo/demosite/__init__.py
+++ b/zenodo/demosite/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/fixtures/__init__.py
+++ b/zenodo/demosite/fixtures/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/fixtures/accounts.py
+++ b/zenodo/demosite/fixtures/accounts.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/fixtures/communities.py
+++ b/zenodo/demosite/fixtures/communities.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
-## Copyright (C) 2014 CERN.
+## This file is part of Zenodo.
+## Copyright (C) 2014, 2015 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
@@ -28,7 +28,7 @@ from fixture import DataSet
 class CommunityData(DataSet):
     class zenodo:
         id = 'zenodo'
-        title = 'ZENODO'
+        title = 'Zenodo'
         id_user = 2
         has_logo = False
 

--- a/zenodo/demosite/fixtures/dumprecords.py
+++ b/zenodo/demosite/fixtures/dumprecords.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/fixtures/formatter.py
+++ b/zenodo/demosite/fixtures/formatter.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/fixtures/indicies.py
+++ b/zenodo/demosite/fixtures/indicies.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/fixtures/knowledgebase.py
+++ b/zenodo/demosite/fixtures/knowledgebase.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/fixtures/oairepository.py
+++ b/zenodo/demosite/fixtures/oairepository.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/fixtures/search.py
+++ b/zenodo/demosite/fixtures/search.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/models.py
+++ b/zenodo/demosite/models.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/demosite/receivers.py
+++ b/zenodo/demosite/receivers.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/ext/__init__.py
+++ b/zenodo/ext/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/fabric.py
+++ b/zenodo/fabric.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/__init__.py
+++ b/zenodo/legacy/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/pidstore_admin.py
+++ b/zenodo/legacy/pidstore_admin.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/pidstore_model.py
+++ b/zenodo/legacy/pidstore_model.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/pidstore_providers.py
+++ b/zenodo/legacy/pidstore_providers.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/resources/bibexport/sitemap.cfg
+++ b/zenodo/legacy/resources/bibexport/sitemap.cfg
@@ -1,4 +1,4 @@
 [export_job]
 export_method = sitemap
-collection1 = ZENODO
+collection1 = Zenodo
 fulltext_status =

--- a/zenodo/legacy/tasklets/bst_load_openaire_kbs.py
+++ b/zenodo/legacy/tasklets/bst_load_openaire_kbs.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2012, 2013 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/tasklets/bst_openaire_altmetric.py
+++ b/zenodo/legacy/tasklets/bst_openaire_altmetric.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2012, 2013 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/tasklets/bst_openaire_check_rights.py
+++ b/zenodo/legacy/tasklets/bst_openaire_check_rights.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2012, 2013 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/tasklets/bst_openaire_pgreplayqueue.py
+++ b/zenodo/legacy/tasklets/bst_openaire_pgreplayqueue.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/__init__.py
+++ b/zenodo/legacy/utils/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/apachelog_export.py
+++ b/zenodo/legacy/utils/apachelog_export.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/bibuploadutils.py
+++ b/zenodo/legacy/utils/bibuploadutils.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/csv_importer.py
+++ b/zenodo/legacy/utils/csv_importer.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/dnetutils.py
+++ b/zenodo/legacy/utils/dnetutils.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/fix_8560.py
+++ b/zenodo/legacy/utils/fix_8560.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/fix_8564.py
+++ b/zenodo/legacy/utils/fix_8564.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/migrate_newcollection_tree.py
+++ b/zenodo/legacy/utils/migrate_newcollection_tree.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/testutils_clients.py
+++ b/zenodo/legacy/utils/testutils_clients.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/validators.py
+++ b/zenodo/legacy/utils/validators.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/validators_openaire_unit_tests.py
+++ b/zenodo/legacy/utils/validators_openaire_unit_tests.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/utils/zenodoutils.py
+++ b/zenodo/legacy/utils/zenodoutils.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/webinterface_handler_local.py
+++ b/zenodo/legacy/webinterface_handler_local.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/legacy/websession_templates_openaire.py
+++ b/zenodo/legacy/websession_templates_openaire.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/__init__.py
+++ b/zenodo/modules/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/__init__.py
+++ b/zenodo/modules/citationformatter/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/config.py
+++ b/zenodo/modules/citationformatter/config.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/static/js/citationformatter/citationformatter.js
+++ b/zenodo/modules/citationformatter/static/js/citationformatter/citationformatter.js
@@ -1,19 +1,19 @@
 /*
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/templates/citationformatter/macros.html
+++ b/zenodo/modules/citationformatter/templates/citationformatter/macros.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/templates/citationformatter/macros_base.html
+++ b/zenodo/modules/citationformatter/templates/citationformatter/macros_base.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/testsuite/__init__.py
+++ b/zenodo/modules/citationformatter/testsuite/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/testsuite/js/citationformatter.spec.js
+++ b/zenodo/modules/citationformatter/testsuite/js/citationformatter.spec.js
@@ -1,19 +1,19 @@
 /*
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/testsuite/test_views.py
+++ b/zenodo/modules/citationformatter/testsuite/test_views.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/citationformatter/views.py
+++ b/zenodo/modules/citationformatter/views.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/communities/__init__.py
+++ b/zenodo/modules/communities/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/communities/receivers.py
+++ b/zenodo/modules/communities/receivers.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/communities/views.py
+++ b/zenodo/modules/communities/views.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/__init__.py
+++ b/zenodo/modules/deposit/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/autocomplete.py
+++ b/zenodo/modules/deposit/autocomplete.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/fields/__init__.py
+++ b/zenodo/modules/deposit/fields/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/fields/access_rights_field.py
+++ b/zenodo/modules/deposit/fields/access_rights_field.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/fields/core.py
+++ b/zenodo/modules/deposit/fields/core.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/fields/license_field.py
+++ b/zenodo/modules/deposit/fields/license_field.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/fields/objecttype_field.py
+++ b/zenodo/modules/deposit/fields/objecttype_field.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/fields/related_identifiers_field.py
+++ b/zenodo/modules/deposit/fields/related_identifiers_field.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/fields/reserve_doi_field.py
+++ b/zenodo/modules/deposit/fields/reserve_doi_field.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/fields/upload_subtype_field.py
+++ b/zenodo/modules/deposit/fields/upload_subtype_field.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/forms.py
+++ b/zenodo/modules/deposit/forms.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/receivers.py
+++ b/zenodo/modules/deposit/receivers.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/tasklets/__init__.py
+++ b/zenodo/modules/deposit/tasklets/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/tasklets/bst_openaire_new_upload.py
+++ b/zenodo/modules/deposit/tasklets/bst_openaire_new_upload.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/tasks.py
+++ b/zenodo/modules/deposit/tasks.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/templates/deposit/widget_plupload_index.html
+++ b/zenodo/modules/deposit/templates/deposit/widget_plupload_index.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software; you can redistribute it and/or
+## Zenodo is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
 ## published by the Free Software Foundation; either version 2 of the
 ## License, or (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful, but
+## Zenodo is distributed in the hope that it will be useful, but
 ## WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ## General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO; if not, write to the Free Software Foundation, Inc.,
+## along with Zenodo; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities

--- a/zenodo/modules/deposit/testsuite/__init__.py
+++ b/zenodo/modules/deposit/testsuite/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/testsuite/test_deposit_objects.py
+++ b/zenodo/modules/deposit/testsuite/test_deposit_objects.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/validators.py
+++ b/zenodo/modules/deposit/validators.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/views.py
+++ b/zenodo/modules/deposit/views.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/workflows/__init__.py
+++ b/zenodo/modules/deposit/workflows/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/deposit/workflows/upload.py
+++ b/zenodo/modules/deposit/workflows/upload.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
-## Copyright (C) 2012, 2013, 2014 CERN.
+## This file is part of Zenodo.
+## Copyright (C) 2012, 2013, 2014, 2015 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
@@ -117,7 +117,7 @@ def process_draft(draft):
     """
     Process loaded form JSON
     """
-    # Filter out ZENODO and OpenAIRE communities
+    # Filter out Zenodo and OpenAIRE communities
     draft.values['communities'] = filter(
         lambda c: c['identifier'] not in [CFG_ZENODO_USER_COLLECTION_ID,
                                           CFG_ECFUNDED_USER_COLLECTION_ID],
@@ -306,14 +306,14 @@ def process_recjson_new(deposition, recjson):
     # ===========
     # Communities
     # ===========
-    # Specific ZENODO user collection, used to curate content for
-    # ZENODO
+    # Specific Zenodo user collection, used to curate content for
+    # Zenodo
     if CFG_ZENODO_USER_COLLECTION_ID not in recjson['provisional_communities']:
         recjson['provisional_communities'].append(
             CFG_ZENODO_USER_COLLECTION_ID
         )
 
-    # Specific ZENODO user collection for OpenAIRE (used to curate
+    # Specific Zenodo user collection for OpenAIRE (used to curate
     # FP7 funded research)
     if recjson.get('grants', []) and CFG_ECFUNDED_USER_COLLECTION_ID \
        not in recjson['provisional_communities']:
@@ -406,7 +406,7 @@ def merge(deposition, dest, a, b):
     b['communities'] = communities
     b['provisional_communities'] = provisional
 
-    # Append ZENODO collection
+    # Append Zenodo collection
     if CFG_ZENODO_USER_COLLECTION_ID in dest['communities']:
         a['communities'].append(CFG_ZENODO_USER_COLLECTION_ID)
         b['communities'].append(CFG_ZENODO_USER_COLLECTION_ID)
@@ -560,7 +560,7 @@ def api_validate_files():
 # ===============
 class upload(DepositionType):
     """
-    ZENODO deposition workflow
+    Zenodo deposition workflow
     """
     workflow = [
         p.IF_ELSE(

--- a/zenodo/modules/github/__init__.py
+++ b/zenodo/modules/github/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013, 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/badge.py
+++ b/zenodo/modules/github/badge.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/bundles.py
+++ b/zenodo/modules/github/bundles.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/config.py
+++ b/zenodo/modules/github/config.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/static/js/github/init.js
+++ b/zenodo/modules/github/static/js/github/init.js
@@ -1,19 +1,19 @@
 /*
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/static/js/github/view.js
+++ b/zenodo/modules/github/static/js/github/view.js
@@ -1,19 +1,19 @@
 /*
- * This file is part of ZENODO.
+ * This file is part of Zenodo.
  * Copyright (C) 2014 CERN.
  *
- * ZENODO is free software: you can redistribute it and/or modify
+ * Zenodo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * ZENODO is distributed in the hope that it will be useful,
+ * Zenodo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+ * along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
  *
  * In applying this licence, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/tasks.py
+++ b/zenodo/modules/github/tasks.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
-## Copyright (C) 2014 CERN.
+## This file is part of Zenodo.
+## Copyright (C) 2014, 2015 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
@@ -138,7 +138,7 @@ def extract_description(gh, release, repository):
 
 
 def extract_metadata(gh, payload):
-    """ Extract metadata for ZENODO from a release. """
+    """ Extract metadata for Zenodo from a release. """
     release = payload["release"]
     repository = payload["repository"]
 

--- a/zenodo/modules/github/testsuite/fixtures.py
+++ b/zenodo/modules/github/testsuite/fixtures.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/testsuite/helpers.py
+++ b/zenodo/modules/github/testsuite/helpers.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/testsuite/test_authentication.py
+++ b/zenodo/modules/github/testsuite/test_authentication.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/testsuite/test_tasks.py
+++ b/zenodo/modules/github/testsuite/test_tasks.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/testsuite/test_upload.py
+++ b/zenodo/modules/github/testsuite/test_upload.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/views/__init__.py
+++ b/zenodo/modules/github/views/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/views/badge.py
+++ b/zenodo/modules/github/views/badge.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/views/github.py
+++ b/zenodo/modules/github/views/github.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/github/views/handlers.py
+++ b/zenodo/modules/github/views/handlers.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/__init__.py
+++ b/zenodo/modules/grants/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/config.py
+++ b/zenodo/modules/grants/config.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/contrib/__init__.py
+++ b/zenodo/modules/grants/contrib/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/contrib/openaire.py
+++ b/zenodo/modules/grants/contrib/openaire.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/tasks.py
+++ b/zenodo/modules/grants/tasks.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/testsuite/__init__.py
+++ b/zenodo/modules/grants/testsuite/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/testsuite/fixtures.py
+++ b/zenodo/modules/grants/testsuite/fixtures.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/testsuite/test_contrib_openaire.py
+++ b/zenodo/modules/grants/testsuite/test_contrib_openaire.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/grants/testsuite/test_tasks.py
+++ b/zenodo/modules/grants/testsuite/test_tasks.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/inspire/config.py
+++ b/zenodo/modules/inspire/config.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/inspire/tasks.py
+++ b/zenodo/modules/inspire/tasks.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2014 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/inspire/views.py
+++ b/zenodo/modules/inspire/views.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2014 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/__init__.py
+++ b/zenodo/modules/preservationmeter/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/api.py
+++ b/zenodo/modules/preservationmeter/api.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/config.py
+++ b/zenodo/modules/preservationmeter/config.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2014 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/recordext/__init__.py
+++ b/zenodo/modules/preservationmeter/recordext/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/recordext/fields/preservationmeter.cfg
+++ b/zenodo/modules/preservationmeter/recordext/fields/preservationmeter.cfg
@@ -1,18 +1,18 @@
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2012, 2013 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/tasks.py
+++ b/zenodo/modules/preservationmeter/tasks.py
@@ -1,20 +1,20 @@
 ## -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/templates/preservationmeter/preservation_best_practice.html
+++ b/zenodo/modules/preservationmeter/templates/preservationmeter/preservation_best_practice.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/templates/preservationmeter/preservation_best_practice_base.html
+++ b/zenodo/modules/preservationmeter/templates/preservationmeter/preservation_best_practice_base.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/templates/preservationmeter/preservation_meter.html
+++ b/zenodo/modules/preservationmeter/templates/preservationmeter/preservation_meter.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/templates/preservationmeter/preservation_meter_base.html
+++ b/zenodo/modules/preservationmeter/templates/preservationmeter/preservation_meter_base.html
@@ -1,19 +1,19 @@
 {#
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/testsuite/__init__.py
+++ b/zenodo/modules/preservationmeter/testsuite/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/testsuite/test_api.py
+++ b/zenodo/modules/preservationmeter/testsuite/test_api.py
@@ -1,20 +1,20 @@
 ## -*- coding: utf-8 -*-
 ##
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/testsuite/test_tasks.py
+++ b/zenodo/modules/preservationmeter/testsuite/test_tasks.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/modules/preservationmeter/views.py
+++ b/zenodo/modules/preservationmeter/views.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of ZENODO.
+# This file is part of Zenodo.
 # Copyright (C) 2014 CERN.
 #
-# ZENODO is free software: you can redistribute it and/or modify
+# Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# ZENODO is distributed in the hope that it will be useful,
+# Zenodo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 #
 # In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/testsuite/__init__.py
+++ b/zenodo/testsuite/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/testsuite/test_record_export.py
+++ b/zenodo/testsuite/test_record_export.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/testsuite/test_record_templates.py
+++ b/zenodo/testsuite/test_record_templates.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization

--- a/zenodo/version.py
+++ b/zenodo/version.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of ZENODO.
+## This file is part of Zenodo.
 ## Copyright (C) 2014 CERN.
 ##
-## ZENODO is free software: you can redistribute it and/or modify
+## Zenodo is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or
 ## (at your option) any later version.
 ##
-## ZENODO is distributed in the hope that it will be useful,
+## Zenodo is distributed in the hope that it will be useful,
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ## GNU General Public License for more details.
 ##
 ## You should have received a copy of the GNU General Public License
-## along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## In applying this licence, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization


### PR DESCRIPTION
* Standardises the service name from "ZENODO to "Zenodo" everywhere in
  the source code, except in sensitive places such as DataCite
  "CERN.ZENODO" ID.

* Adds migration recipe to switch collection and doctype names in the
  database from "ZENODO" to "Zenodo", even though case-insensitive
  matching mode would probably worked out with old names anyway.

* NOTE The reason for change: the practice showed that the service is
  being referred to mostly as "Zenodo", so we decided to switch the
  visible name everywhere to this form as well.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>