### PR TITLE
base: fix bibtex formatter subtypes handling

### DIFF
--- a/zenodo/base/utils/bibtex.py
+++ b/zenodo/base/utils/bibtex.py
@@ -93,8 +93,8 @@ class Bibtex(object):
                               self._format_misc],
             'workingpaper': [self._format_unpublished,
                              self._format_misc],
-            'other': self._format_misc,
-            'default': self._format_misc,
+            'other': [self._format_misc],
+            'default': [self._format_misc],
         }
         subtype = self._get_entry_subtype()
         if subtype in formats:


### PR DESCRIPTION
* Fixes `other` and `default` subtypes handling in Bibtex formater.

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>