### PR TITLE
base: record title in export pages

### DIFF
--- a/zenodo/base/templates/format/record/Default_HTML_BibTeX.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_BibTeX.tpl
@@ -21,5 +21,7 @@
 #}
 
 {% from "helpers.html" import copy_to_clipboard -%}
-<h1>BibTeX Export {{copy_to_clipboard(clipboard_target='clipboard_text')}}</h1>
+<h1>{{record.title}}</h1>
+<br>
+<h2>BibTeX Export {{copy_to_clipboard(clipboard_target='clipboard_text')}}</h2>
 <pre id="clipboard_text">{{ record|bibtex }}</pre>

--- a/zenodo/base/templates/format/record/Default_HTML_MARC.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_MARC.tpl
@@ -1,3 +1,5 @@
 {% from "helpers.html" import copy_to_clipboard -%}
-<h1>MARC Export {{copy_to_clipboard(clipboard_target='clipboard_text')}}</h1>
+<h1>{{record.title}}</h1>
+<br>
+<h2>MARC Export {{copy_to_clipboard(clipboard_target='clipboard_text')}}</h2>
 <pre id="clipboard_text">{{ tfn_get_fieldvalues_alephseq_like(recid, [], current_user.get('precached_canseehiddenmarctags', False))|safe }}</pre>


### PR DESCRIPTION
* Adds record title in `h1` tag of the export pages. (closes #81)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>