### PR TITLE
github: list your repositories GitHub API changes

### DIFF
--- a/zenodo/modules/github/testsuite/fixtures.py
+++ b/zenodo/modules/github/testsuite/fixtures.py
@@ -87,6 +87,10 @@ def register_github_api():
         "/users/cuser",
         USER('cuser', email='cuser@invenio-software.org')
     )
+    register_endpoint(
+        "/user/repos",
+        [REPO('auser', 'repo-1'), REPO('auser', 'repo-2')]
+    )
     httpretty.register_uri(
         httpretty.GET,
         "https://api.github.com/repos/auser/repo-1/zipball/v1.0",


### PR DESCRIPTION
* moves from using `users/:username/repos` to `user/repos`
  API call to get the list of the users repositories. (closes #86)

* NOTE: List your repositories GitHub API now also includes
        repositories owned by organizations which the user
        can access.

        This functionality will apply to all API consumers
        beginning February 24, 2015.

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>

<!---
@huboard:{"milestone_order":116.9375,"order":30.0,"custom_state":""}
-->
