### PR TITLE
deposit: better doi validation in edit form

### DIFF
--- a/zenodo/modules/deposit/forms.py
+++ b/zenodo/modules/deposit/forms.py
@@ -942,6 +942,7 @@ class ZenodoEditForm(ZenodoForm, EditFormMixin):
             local_datacite_lookup
         ],
         export_key='doi',
+        readonly="true"
     )
     prereserve_doi = None
     plupload_file = None

--- a/zenodo/modules/deposit/workflows/upload.py
+++ b/zenodo/modules/deposit/workflows/upload.py
@@ -424,6 +424,8 @@ def merge(deposition, dest, a, b):
         a['provisional_communities'].append(CFG_ECFUNDED_USER_COLLECTION_ID)
         b['provisional_communities'].append(CFG_ECFUNDED_USER_COLLECTION_ID)
 
+    b["doi"] = a["doi"]
+
     # Now proceed, with normal merging.
     data = merge_changes(deposition, dest, a, b)
 


### PR DESCRIPTION
* Adds validation to prevent removal of existing doi. (addresses #231)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>