### PR TITLE
github: doi link in badge modal dialog

### DIFF
--- a/zenodo/modules/github/templates/github/helpers.html
+++ b/zenodo/modules/github/templates/github/helpers.html
@@ -1,6 +1,6 @@
 {#
 ## This file is part of Invenio.
-## Copyright (C) 2014 CERN.
+## Copyright (C) 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -42,6 +42,9 @@
 
               <h4><small>Image URL</small><h4>
               <pre>{{image_url}}</pre>
+
+              <h4><small>DOI URL</small><h4>
+              <pre>{{doi_url}}</pre>
             </div>
           </div>
         </div>


### PR DESCRIPTION
* Adds doi link in badge modal dialog. (closes #204)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>