### PR TITLE
base: records info text overflow fix

### DIFF
--- a/zenodo/base/static/less/zenodo.less
+++ b/zenodo/base/static/less/zenodo.less
@@ -684,6 +684,10 @@ h1, h2, h3 {
   color: #fff;
 }
 
+.metadata .label[itemprop=keywords] {
+  white-space: normal;
+}
+
 .tablink img {
   display: none;
 }

--- a/zenodo/base/static/less/zenodo.less
+++ b/zenodo/base/static/less/zenodo.less
@@ -672,6 +672,9 @@ h1, h2, h3 {
     display: inline;
 }
 
+.metadata {
+  word-wrap: break-word;
+}
 
 .metadata dt {
   font-weight: bold;


### PR DESCRIPTION
* Adds word wrap in records' info. (closes #101)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>

----

* Fixes how keywords are wrapped. (closes #77)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>