### PR TITLE
base: duplicated github logo fix

### DIFF
--- a/zenodo/base/views.py
+++ b/zenodo/base/views.py
@@ -269,12 +269,6 @@ RULES = {
         'scheme': 'doi',
         'text': 'Published in',
         'image': 'img/ieee.jpg',
-        }, {
-        'prefix': 'https://github.com',
-        'relation': 'isSupplementTo',
-        'scheme': 'url',
-        'text': 'Available in',
-        'image': 'img/github.png',
         }],
 }
 


### PR DESCRIPTION
* Removes duplicated definition. (closes #240)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>