### PR TITLE
base: update briefideas logo url

### DIFF
--- a/zenodo/base/views.py
+++ b/zenodo/base/views.py
@@ -251,7 +251,7 @@ RULES = {
         'image': 'img/inspirehep.png',
         }],
     'briefideas': [{
-        'prefix': 'http://ideas.theoj.org/',
+        'prefix': 'http://beta.briefideas.org/',
         'relation': 'isIdenticalTo',
         'scheme': 'url',
         'text': 'Published in',


### PR DESCRIPTION
* Changes url of briefideas logo. (addresses #203)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>