### PR TITLE
base: failing bibtex export fix

### DIFF
--- a/zenodo/base/utils/bibtex.py
+++ b/zenodo/base/utils/bibtex.py
@@ -97,7 +97,7 @@ class Bibtex(object):
             'workingpaper': [self._format_unpublished,
                              self._format_misc],
             'other': [self._format_misc],
-            'default': [self._format_misc],
+            'default': self._format_misc,
         }
         subtype = self._get_entry_subtype()
         if subtype in formats:


### PR DESCRIPTION
* Properly resolves format function for default subtype (closes #247).

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>