### PR TITLE
base: BibTeX KeyError fix

### DIFF
--- a/zenodo/base/utils/bibtex.py
+++ b/zenodo/base/utils/bibtex.py
@@ -211,7 +211,7 @@ class Bibtex(object):
         """
         name = "inproceedings"
         req_fileds = ['author', 'title', 'booktitle', 'year']
-        opt_fileds = ['editor', 'pages', 'organization', 'publisher'
+        opt_fileds = ['editor', 'pages', 'organization', 'publisher',
                       'address', 'month', 'note', 'key']
         ign_fields = ['doi', 'url']
         try:


### PR DESCRIPTION
* Fixes inproceedings optional fields definition. (closes #249)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>