### PR TITLE
base: BibTeX formatter DOI requirement removal

### DIFF
--- a/zenodo/base/testsuite/test_zenodo_bibtex.py
+++ b/zenodo/base/testsuite/test_zenodo_bibtex.py
@@ -158,8 +158,7 @@ class BibTexFormatterTest(InvenioTestCase):
     def test_get_doi(self):
         self.assertEqual(test_record['doi'],
                          self.record_good._get_doi())
-        self.assertRaises(MissingRequiredFieldError,
-                          self.record_empty._get_doi)
+        self.assertIsNone(self.record_empty._get_doi())
 
     def test_get_author(self):
         authors = []

--- a/zenodo/base/utils/bibtex.py
+++ b/zenodo/base/utils/bibtex.py
@@ -211,7 +211,7 @@ class Bibtex(object):
         """
         name = "inproceedings"
         req_fileds = ['author', 'title', 'booktitle', 'year']
-        opt_fileds = ['editor', 'pages', 'organization', 'publisher'
+        opt_fileds = ['editor', 'pages', 'organization', 'publisher',
                       'address', 'month', 'note', 'key']
         ign_fields = ['doi', 'url']
         try:

--- a/zenodo/base/utils/bibtex.py
+++ b/zenodo/base/utils/bibtex.py
@@ -431,7 +431,7 @@ class Bibtex(object):
         if "doi" in self.record:
             return self.record['doi']
         else:
-            raise MissingRequiredFieldError("doi")
+            return None
 
     def _get_author(self):
         """Return list of name(s) of the author(s)."""


### PR DESCRIPTION
This one is rebased on top of https://github.com/zenodo/zenodo/pull/250