### PR TITLE
github: invalid link in doi badge fix

### DIFF
--- a/zenodo/modules/github/templates/github/index_base.html
+++ b/zenodo/modules/github/templates/github/index_base.html
@@ -1,20 +1,20 @@
 {#
-## This file is part of Invenio.
-## Copyright (C) 2013, 2014 CERN.
-##
-## Invenio is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## Invenio is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Invenio; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# This file is part of Invenio.
+# Copyright (C) 2013, 2014, 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #}
 
 {%- import "accounts/settings/helpers.html" as helpers with context %}
@@ -131,7 +131,7 @@ require(['jquery', 'js/github/view'], function($, view) {
                   <pre>{{image_url}}</pre>
 
                   <h4><small>HTML</small><h4>
-                  <pre>&lt;a href="{{doi_url}}"&gt;&lt;img src="{{image_url}}"&gt;&lt;a&gt;</pre>
+                  <pre>&lt;a href="{{doi_url}}"&gt;&lt;img src="{{image_url}}"&gt;&lt;/a&gt;</pre>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
* Corrects closing link tag. (closes #269)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>