### PR TITLE
records: json in datacite xml export fix

### DIFF
--- a/zenodo/base/format_templates/DataCite3.xsl
+++ b/zenodo/base/format_templates/DataCite3.xsl
@@ -346,7 +346,7 @@ exclude-result-prefixes="marc fn dc invenio">
             </xsl:for-each>
             <xsl:if test="datafield[@tag='999' and @ind1='C' and @ind2='5']">
                 <description descriptionType="Other">
-                    {'references' : [
+                    {"references" : [
                     <xsl:for-each select="datafield[@tag='999' and @ind1='C' and @ind2='5']">
                         "<xsl:value-of select="subfield[@code='x']"/>",
                     </xsl:for-each>


### PR DESCRIPTION
* Changes single to double quotes in JSON for references in datacite
  XML. (closes #271)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>