### PR TITLE
records: last comma in json in datacite removal

### DIFF
--- a/zenodo/base/format_templates/DataCite3.xsl
+++ b/zenodo/base/format_templates/DataCite3.xsl
@@ -346,7 +346,7 @@ exclude-result-prefixes="marc fn dc invenio">
             </xsl:for-each>
             <xsl:if test="datafield[@tag='999' and @ind1='C' and @ind2='5']">
                 <description descriptionType="Other">
-                    {'references' : [
+                    {"references" : [
                     <xsl:for-each select="datafield[@tag='999' and @ind1='C' and @ind2='5']">
                         "<xsl:value-of select="subfield[@code='x']"/>",
                     </xsl:for-each>

--- a/zenodo/base/format_templates/DataCite3.xsl
+++ b/zenodo/base/format_templates/DataCite3.xsl
@@ -348,7 +348,7 @@ exclude-result-prefixes="marc fn dc invenio">
                 <description descriptionType="Other">
                     {"references" : [
                     <xsl:for-each select="datafield[@tag='999' and @ind1='C' and @ind2='5']">
-                        "<xsl:value-of select="subfield[@code='x']"/>",
+                        "<xsl:value-of select="subfield[@code='x']"/>"<xsl:if test="position() != last()">,</xsl:if>
                     </xsl:for-each>
                     ]}
                 </description>


### PR DESCRIPTION
* Removes trailing comma from json in datacite export. (closes #277)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>