### PR TITLE
global: new pub subtypes deliverable and milestone

### DIFF
--- a/zenodo/base/upgrades/zenodo_2015_06_02_new_subtype_deliverable_and_milestone.py
+++ b/zenodo/base/upgrades/zenodo_2015_06_02_new_subtype_deliverable_and_milestone.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of ZENODO.
+# Copyright (C) 2015 CERN.
+#
+# ZENODO is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ZENODO is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ZENODO. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from invenio.legacy.dbquery import run_sql
+
+depends_on = [u'zenodo_2015_03_04_firerole_email_to_uid']
+
+
+def info():
+    """Information about the upgrade."""
+    return "New subtypes addition: delivarable and milestone."
+
+
+def do_upgrade():
+    """Implement your upgrades here."""
+    # deliverable addition
+    run_sql(
+        "INSERT INTO collection (name, dbquery) VALUES (%s, %s)",
+        ('deliverable', '980__b:deliverable')
+    )
+    coll_id = run_sql(
+        "SELECT id FROM collection WHERE name='deliverable'")[0][0]
+    run_sql(
+        "INSERT INTO collectiondetailedrecordpagetabs (id_collection, tabs)\
+        VALUES (%s, 'usage;comments;metadata;files')", (coll_id,)
+    )
+    run_sql(
+        "INSERT INTO collection_collection (id_dad, id_son, type, score)\
+        VALUES (%s, %s, %s, %s)", (2, coll_id, 'r', coll_id)
+    )
+    run_sql(
+        "INSERT INTO collectionname (id_collection, ln, type, value)\
+        VALUES (%s, %s, %s, %s)", (coll_id, 'en', 'ln', 'Project Deliverable')
+    )
+
+    # milestone addition
+    run_sql(
+        "INSERT INTO collection (name, dbquery) VALUES (%s, %s)",
+        ('milestone', '980__b:milestone')
+    )
+    coll_id = run_sql(
+        "SELECT id FROM collection WHERE name='milestone'")[0][0]
+    run_sql(
+        "INSERT INTO collectiondetailedrecordpagetabs (id_collection, tabs)\
+        VALUES (%s, 'usage;comments;metadata;files')", (coll_id,)
+    )
+    run_sql(
+        "INSERT INTO collection_collection (id_dad, id_son, type, score)\
+        VALUES (%s, %s, %s, %s)", (2, coll_id, 'r', coll_id)
+    )
+    run_sql(
+        "INSERT INTO collectionname (id_collection, ln, type, value)\
+        VALUES (%s, %s, %s, %s)", (coll_id, 'en', 'ln', 'Project Milestone')
+    )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1

--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -1,24 +1,24 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of Zenodo.
-## Copyright (C) 2012, 2013, 2014, 2015 CERN.
-##
-## Zenodo is free software: you can redistribute it and/or modify
-## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation, either version 3 of the License, or
-## (at your option) any later version.
-##
-## Zenodo is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-## GNU General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
-##
-## In applying this licence, CERN does not waive the privileges and immunities
-## granted to it by virtue of its status as an Intergovernmental Organization
-## or submit itself to any jurisdiction.
+# This file is part of Zenodo.
+# Copyright (C) 2012, 2013, 2014, 2015 CERN.
+#
+# Zenodo is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 """
 Zenodo configuration.
@@ -45,9 +45,9 @@ import sys
 
 from datetime import timedelta
 
-import pkg_resources
-
 from celery.schedules import crontab
+
+import pkg_resources
 
 
 def _(x):
@@ -284,8 +284,8 @@ CFG_BIBFORMAT_ADD_THIS_ID = "ra-4dc80cde118f4dad"
 DEPOSIT_MAX_UPLOAD_SIZE = 2147483648
 CFG_OPENAIRE_FILESIZE_NOTIFICATION = 10485760
 
-#CFG_BROKER_URL = "amqp://openairenext:openairenext@localhost:5672/" \
-#    "openairenext_vhost"
+# CFG_BROKER_URL = "amqp://openairenext:openairenext@localhost:5672/" \
+#     "openairenext_vhost"
 CFG_CELERY_RESULT_BACKEND = "redis://localhost:6379/1"
 
 CELERYBEAT_SCHEDULE = {
@@ -321,7 +321,7 @@ CFG_WEBSEARCH_PUBLIC_RECORD_EXTRA_CHECK = True
 CFG_BIBDOCFILE_FILESYSTEM_BIBDOC_GROUP_LIMIT = 1000
 
 CFG_OPENAIRE_SITE = 1
-#CFG_WEBSTYLE_TEMPLATE_SKIN = "openaire"
+# CFG_WEBSTYLE_TEMPLATE_SKIN = "openaire"
 CFG_WEBSTYLE_HTTP_USE_COMPRESSION = 1
 
 CFG_WEBCOMMENT_ALLOW_SHORT_REVIEWS = 0
@@ -440,6 +440,8 @@ SCHEMAORG_MAP = dict(
     section='http://schema.org/ScholarlyArticle',
     conferencepaper='http://schema.org/ScholarlyArticle',
     article='http://schema.org/ScholarlyArticle',
+    deliverable='http://schema.org/CreativeWork',
+    milestone='http://schema.org/CreativeWork',
     patent='http://schema.org/CreativeWork',
     preprint='http://schema.org/ScholarlyArticle',
     proposal='http://schema.org/CreativeWork',
@@ -495,6 +497,8 @@ CFG_OPENAIRE_PUBTYPE_MAP = [
     ('section', _('Book section')),
     ('conferencepaper', _('Conference paper')),
     ('article', _('Journal article')),
+    ('deliverable', _('Project Deliverable')),
+    ('milestone', _('Project Milestone')),
     ('patent', _('Patent')),
     ('preprint', _('Preprint')),
     ('proposal', _('Proposal')),

--- a/zenodo/demosite/fixtures/search.py
+++ b/zenodo/demosite/fixtures/search.py
@@ -1,24 +1,24 @@
 # -*- coding: utf-8 -*-
 #
-## This file is part of Zenodo.
-## Copyright (C) 2014 CERN.
-##
-## Zenodo is free software: you can redistribute it and/or modify
-## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation, either version 3 of the License, or
-## (at your option) any later version.
-##
-## Zenodo is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-## GNU General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
-##
-## In applying this licence, CERN does not waive the privileges and immunities
-## granted to it by virtue of its status as an Intergovernmental Organization
-## or submit itself to any jurisdiction.
+# This file is part of Zenodo.
+# Copyright (C) 2014, 2015 CERN.
+#
+# Zenodo is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 from fixture import DataSet
 
@@ -64,6 +64,9 @@ colls = [
     # collection it can still be viewed by guest users.
     (29, 'zenodo-public', 'zenodo-public', '980__a:0->Z AND NOT 980__a:PROVISIONAL AND NOT 980__a:PENDING AND NOT 980__a:SPAM AND NOT 980__a:REJECTED AND NOT 980__a:DARK'),
     (30, 'Software', 'software', '980__a:software'),
+    (31, 'Proposal', 'proposal', '980__b:proposal'),
+    (32, 'Project Deliverable', 'deliverable', '980__b:deliverable'),
+    (33, 'Project Milestone', 'milestone', '980__b:milestone'),
 
 ]
 
@@ -112,6 +115,9 @@ coll_coll_data = (
     (1, 25, 'v', 25),
     (1, 26, 'v', 26),
     (1, 28, 'v', 27),
+    (2, 31, 'r', 28),
+    (2, 32, 'r', 29),
+    (2, 33, 'r', 30),
 )
 
 


### PR DESCRIPTION
* Adds `deliverable` and `milestone` subtypes to `Publications`.
  (closes #280)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>

<!---
@huboard:{"order":195.34375,"milestone_order":284,"custom_state":""}
-->
