### PR TITLE
records: link from exports to detail view addition

### DIFF
--- a/zenodo/base/templates/format/record/Default_HTML_BibTeX.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_BibTeX.tpl
@@ -23,5 +23,8 @@
 {% from "helpers.html" import copy_to_clipboard -%}
 <h1>{{record.title}}</h1>
 <br>
-<h2>BibTeX Export {{copy_to_clipboard(clipboard_target='clipboard_text')}}</h2>
+<h2>BibTeX Export
+{{copy_to_clipboard(clipboard_target='clipboard_text')}}
+<a class="btn btn-default btn-xs" href="{{url_for('record.metadata', recid=recid)}}"><i class="fa fa-file-text fa-fw"></i> View record</a>
+</h2>
 <pre id="clipboard_text">{{ record|bibtex }}</pre>

--- a/zenodo/base/templates/format/record/Default_HTML_MARC.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_MARC.tpl
@@ -1,5 +1,8 @@
 {% from "helpers.html" import copy_to_clipboard -%}
 <h1>{{record.title}}</h1>
 <br>
-<h2>MARC Export {{copy_to_clipboard(clipboard_target='clipboard_text')}}</h2>
+<h2>MARC Export
+{{copy_to_clipboard(clipboard_target='clipboard_text')}}
+<a class="btn btn-default btn-xs" href="{{url_for('record.metadata', recid=recid)}}"><i class="fa fa-file-text fa-fw"></i> View record</a>
+</h2>
 <pre id="clipboard_text">{{ tfn_get_fieldvalues_alephseq_like(recid, [], current_user.get('precached_canseehiddenmarctags', False))|safe }}</pre>


### PR DESCRIPTION
* Adds link back to detail view from export pages. (closes #266)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>