### PR TITLE
records: url prefix in alternate ids deletion

### DIFF
--- a/zenodo/base/templates/format/record/Default_HTML_info.tpl
+++ b/zenodo/base/templates/format/record/Default_HTML_info.tpl
@@ -42,7 +42,7 @@
     {%- set alternate_url = alternateid|pid_url -%}
     {%- if loop.first %}<dt>Alternate identifiers:</dt><dd>{% endif %}
         {%- if alternate_url -%}
-            <a href="{{alternate_url}}">{{alternateid.scheme}}:{{alternateid.identifier}}</a>
+            <a href="{{alternate_url}}">{%- if alternateid.scheme != "url" %}{{alternateid.scheme}}:{%- endif %}{{alternateid.identifier}}</a>
         {%- else -%}
             {{alternateid.scheme}}:{{alternateid.identifier}}
         {%- endif -%}


### PR DESCRIPTION
* Makes sure url schema prefix is not shown. (closes #262)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>