### PR TITLE
deposit: api documentation

### DIFF
--- a/zenodo/base/templates/zenodo/api.html
+++ b/zenodo/base/templates/zenodo/api.html
@@ -1713,6 +1713,7 @@ r = requests.post("{{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234/a
     <td>Controlled vocabulary:<ul>
       <li><code>open</code>: Open Access</li>
 <li><code>embargoed</code>: Embargoed Access</li>
+<li><code>restricted</code>: Restricted Access</li>
 <li><code>closed</code>: Closed Access</li>
     </ul>Defaults to <code>open</code>.</td>
 </tr>
@@ -1728,6 +1729,12 @@ r = requests.post("{{config.CFG_SITE_SECURE_URL}}/api/deposit/depositions/1234/a
     <td></td>
     <td>Yes, if <code>access_right</code> is <code>"embargoed"</code>.</td>
     <td>Date in ISO8601 format (<code>YYYY-MM-DD</code>) when the deposited files will be made automatically made publicly available by the system. Defaults to current date.</td>
+</tr>
+<tr>
+    <td><code>access_conditions</code></td>
+    <td>String</td>
+    <td>Yes, if <code>access_right</code> is <code>"restricted"</code>.</td>
+    <td>Specify the conditions under which you grant users access to the files in your upload. User requesting access will be asked to justify how they fulfil the conditions. Based on the justification, you decide who to grant/deny access. You are not allowed to charge users for granting access to data hosted on Zenodo. Following HTML tags are allowed: <code>a</code>, <code>p</code>, <code>br</code>, <code>blockquote</code>, <code>strong</code>, <code>b</code>, <code>u</code>, <code>i</code>, <code>em</code>, <code>ul</code>, <code>ol</code>, <code>li</code>, <code>sub</code>, <code>sup</code>, <code>div</code>, <code>strike</code>.</td>
 </tr>
 <tr>
     <td><code>doi</code></td>

--- a/zenodo/modules/deposit/testsuite/test_zenodo_api.py
+++ b/zenodo/modules/deposit/testsuite/test_zenodo_api.py
@@ -454,6 +454,7 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
             type='string',
             allowed=['open', 'closed', 'embargoed', 'restricted'],
         ),
+        access_conditions=dict(type='string'),
         communities=dict(type='list'),
         conference_acronym=dict(type='string'),
         conference_dates=dict(type='string'),
@@ -702,7 +703,8 @@ class WebDepositZenodoApiTest(DepositApiTestCase):
     def test_unicode(self):
         test_data = dict(
             metadata=dict(
-                access_right='embargoed',
+                access_right='restricted',
+                access_conditions='Αυτή είναι μια δοκιμή',
                 communities=[{'identifier': 'cfa'}],
                 conference_acronym='Αυτή είναι μια δοκιμή',
                 conference_dates='هذا هو اختبار',

--- a/zenodo/modules/deposit/workflows/upload.py
+++ b/zenodo/modules/deposit/workflows/upload.py
@@ -649,6 +649,7 @@ class upload(DepositionType):
 
     marshal_metadata_fields = dict(
         access_right=fields.String,
+        access_conditions=fields.String,
         communities=fields.List(fields.Raw),
         conference_acronym=fields.String,
         conference_dates=fields.String,


### PR DESCRIPTION
* Adds API documentation for restricted access mode, as well as
  access_conditions field. (#closes 263)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>