### PR TITLE
quotas: xsls metrics publisher

### DIFF
--- a/base.requirements.txt
+++ b/base.requirements.txt
@@ -70,6 +70,7 @@ beautifulsoup4==4.3.2
 billiard==3.3.0.20
 blinker==1.3
 celery==3.1.18
+cernservicexml==0.1.2
 cffi==1.1.0
 chardet==2.3.0
 click==4.0

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ install_requires = [
     "Pillow",
     "pyoai>=2.4.2",
     "awesome-slugify>=1.6",
+    "cernservicexml>=0.1.2",
 ]
 
 extras_require = {

--- a/zenodo/base/metrics/__init__.py
+++ b/zenodo/base/metrics/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Zenodo.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2012, 2013 CERN.
 #
 # Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,31 +20,14 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Registry of metric classes."""
 
-from flask_registry import ImportPathRegistry, RegistryProxy, RegistryError
+def availability(doc):
+    """Compute availability for Zenodo - primarily used for bibsched."""
+    for d in doc.data:
+        if d['name'] == 'bibsched.tasks':
+            if d['value'] > 20:
+                return 10
+            elif d['value'] > 10:
+                return 60
 
-from invenio.base.globals import cfg
-
-from .models import Metric
-
-
-class MetricsRegistry(ImportPathRegistry):
-
-    """Metrics registry."""
-
-    def __init__(self):
-        """Set defaults."""
-        super(MetricsRegistry, self).__init__(
-            initial=cfg.get('QUOTAS_METRICS', []),
-            load_modules=True,
-        )
-
-    def _load_import_path(self, import_path):
-        """Load module behind an import path."""
-        m = super(MetricsRegistry, self)._load_import_path(import_path)
-        if not issubclass(Metric, m):
-            raise RegistryError("{0} is not a subclass of Metric.")
-
-
-metrics_registry = RegistryProxy('quotas_metrics', MetricsRegistry)
+    return 100

--- a/zenodo/base/metrics/communities.py
+++ b/zenodo/base/metrics/communities.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Zenodo.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2012, 2013 CERN.
 #
 # Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,31 +20,29 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Registry of metric classes."""
+"""Communities metrics."""
 
-from flask_registry import ImportPathRegistry, RegistryProxy, RegistryError
+from __future__ import absolute_import
 
-from invenio.base.globals import cfg
+from flask import current_app
 
-from .models import Metric
+from invenio.modules.communities.models import Community
 
-
-class MetricsRegistry(ImportPathRegistry):
-
-    """Metrics registry."""
-
-    def __init__(self):
-        """Set defaults."""
-        super(MetricsRegistry, self).__init__(
-            initial=cfg.get('QUOTAS_METRICS', []),
-            load_modules=True,
-        )
-
-    def _load_import_path(self, import_path):
-        """Load module behind an import path."""
-        m = super(MetricsRegistry, self)._load_import_path(import_path)
-        if not issubclass(Metric, m):
-            raise RegistryError("{0} is not a subclass of Metric.")
+from zenodo.modules.quotas.models import Metric
 
 
-metrics_registry = RegistryProxy('quotas_metrics', MetricsRegistry)
+class CommunitiesMetric(Metric):
+
+    """Aggregated metrics for communities."""
+
+    metric_class = "communities"
+    object_type = "System"
+
+    @classmethod
+    def all(cls):
+        """Compute bibsched queue length."""
+        system_name = current_app.config.get('CFG_SITE_NAME', 'Invenio')
+        data = {system_name: {
+            'num': Community.query.count(),
+        }}
+        return data.items()

--- a/zenodo/base/metrics/pidstore.py
+++ b/zenodo/base/metrics/pidstore.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Zenodo.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2012, 2013 CERN.
 #
 # Zenodo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,31 +20,31 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Registry of metric classes."""
+"""PIDStore metrics."""
 
-from flask_registry import ImportPathRegistry, RegistryProxy, RegistryError
+from __future__ import absolute_import
 
-from invenio.base.globals import cfg
+from flask import current_app
 
-from .models import Metric
+from invenio.modules.pidstore.models import PersistentIdentifier
 
-
-class MetricsRegistry(ImportPathRegistry):
-
-    """Metrics registry."""
-
-    def __init__(self):
-        """Set defaults."""
-        super(MetricsRegistry, self).__init__(
-            initial=cfg.get('QUOTAS_METRICS', []),
-            load_modules=True,
-        )
-
-    def _load_import_path(self, import_path):
-        """Load module behind an import path."""
-        m = super(MetricsRegistry, self)._load_import_path(import_path)
-        if not issubclass(Metric, m):
-            raise RegistryError("{0} is not a subclass of Metric.")
+from zenodo.modules.quotas.models import Metric
 
 
-metrics_registry = RegistryProxy('quotas_metrics', MetricsRegistry)
+class PIDStoreMetric(Metric):
+
+    """Aggregated metrics for pidstore."""
+
+    metric_class = "pidstore"
+    object_type = "System"
+
+    @classmethod
+    def all(cls):
+        """Compute bibsched queue length."""
+        system_name = current_app.config.get('CFG_SITE_NAME', 'Invenio')
+        dois = PersistentIdentifier.query.filter_by(pid_type='doi',
+                                                    status='R').count()
+        data = {system_name: {
+            'numdois': dois,
+        }}
+        return data.items()

--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -308,6 +308,34 @@ CELERYBEAT_SCHEDULE = {
         schedule=crontab(minute='*/15'),
         args=('zenodo.modules.quotas.metrics.afs:AFSVolumeMetric', ),
     ),
+    # Every 5
+    'metrics-bibsched': dict(
+        task='zenodo.modules.quotas.tasks.collect_metric',
+        schedule=crontab(minute='*/5'),
+        args=('zenodo.modules.quotas.metrics.bibsched:BibSchedMetric', ),
+    ),
+    # Every hour
+    'metrics-accounts': dict(
+        task='zenodo.modules.quotas.tasks.collect_metric',
+        schedule=crontab(minute=0, hour='*/1'),
+        args=('zenodo.modules.quotas.metrics.accounts:AccountsMetric', ),
+    ),
+    # Every 3 hour
+    'metrics-communities': dict(
+        task='zenodo.modules.quotas.tasks.collect_metric',
+        schedule=crontab(minute=1, hour='*/3'),
+        args=('zenodo.base.metrics.communities:CommunitiesMetric', ),
+    ),
+    'metrics-pidstore': dict(
+        task='zenodo.modules.quotas.tasks.collect_metric',
+        schedule=crontab(minute=1, hour='*/3'),
+        args=('zenodo.base.metrics.pidstore:PIDStoreMetric', ),
+    ),
+    'publish-metrics': dict(
+        task='zenodo.modules.quotas.tasks.publish_metrics',
+        schedule=crontab(minute='*/15'),
+        args=('zenodo.modules.quotas.publishers.cern:CERNPublisher', ),
+    ),
     # # Every 12 hours
     # 'metrics-deposit': dict(
     #     task='zenodo.modules.quotas.tasks.collect_metric',
@@ -321,6 +349,17 @@ CELERYBEAT_SCHEDULE = {
         args=(),
     ),
 }
+
+QUOTAS_PUBLISH_METRICS = [
+    dict(type='System', id=CFG_SITE_NAME, metric='bibsched.tasks'),
+    dict(type='System', id=CFG_SITE_NAME, metric='accounts.num'),
+    dict(type='System', id=CFG_SITE_NAME, metric='accounts.logins6h'),
+    dict(type='System', id=CFG_SITE_NAME, metric='communities.num'),
+    dict(type='System', id=CFG_SITE_NAME, metric='pidstore.numdois'),
+]
+QUOTAS_XSLS_API_URL = "http://xsls-dev.cern.ch"
+QUOTAS_XSLS_SERVICE_ID = "zenododev"
+QUOTAS_XSLS_AVAILABILITY = 'zenodo.base.metrics:availability'
 
 CFG_WEBSEARCH_ENABLE_OPENGRAPH = True
 CFG_WEBSEARCH_DISPLAY_NEAREST_TERMS = False

--- a/zenodo/modules/quotas/config.py
+++ b/zenodo/modules/quotas/config.py
@@ -28,7 +28,30 @@ QUOTAS_METRICS = [
     'zenodo.modules.quotas.metrics.deposit:DepositMetric',
 ]
 
+QUOTAS_PUBLISH_METRICS = []
+"""Determine which metrics to publish."""
+
 QUOTAS_AFSMETRIC_DIRECTORIES = [
     "var/data/deposit/",
     "var/data/files/",
 ]
+"""AFS directories for AFS metric."""
+
+#
+# XSLS related variables.
+#
+
+QUOTAS_XSLS_API_URL = "http://xsls-dev.cern.ch"
+"""XSLS API endpoint."""
+
+QUOTAS_XSLS_SERVICE_ID = None
+"""XSLS service id."""
+
+QUOTAS_XSLS_AVAILABILITY = 'zenodo.base.metrics.availability'
+"""Import path to callable that will compute an availability value (0-100).
+
+The callable must take one argument which is the ServiceDocument that will
+be sent to the XSLS service.
+
+See http://itmon.web.cern.ch/itmon/recipes/how_to_create_a_service_xml.html
+"""

--- a/zenodo/modules/quotas/metrics/accounts.py
+++ b/zenodo/modules/quotas/metrics/accounts.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Account metrics."""
+
+from __future__ import absolute_import
+
+from datetime import datetime, timedelta
+
+from flask import current_app
+
+from invenio.modules.accounts.models import User
+
+from ..models import Metric
+
+
+class AccountsMetric(Metric):
+
+    """Aggregated metrics for number of accounts."""
+
+    metric_class = "accounts"
+    object_type = "System"
+
+    @classmethod
+    def all(cls):
+        """Compute bibsched queue length."""
+        dt = datetime.now() - timedelta(hours=6)
+
+        system_name = current_app.config.get('CFG_SITE_NAME', 'Invenio')
+        data = {system_name: {
+            'num': User.query.count(),
+            'logins6h': User.query.filter(User.last_login >= dt).count(),
+        }}
+        return data.items()

--- a/zenodo/modules/quotas/metrics/bibsched.py
+++ b/zenodo/modules/quotas/metrics/bibsched.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Bibsched metrics."""
+
+from __future__ import absolute_import
+
+from flask import current_app
+
+from invenio.modules.scheduler.models import SchTASK
+
+from ..models import Metric
+
+
+class BibSchedMetric(Metric):
+
+    """Number of waiting tasks in bibsched queue."""
+
+    metric_class = "bibsched"
+    object_type = "System"
+
+    @classmethod
+    def all(cls):
+        """Compute bibsched queue length."""
+        system_name = current_app.config.get('CFG_SITE_NAME', 'Invenio')
+        data = {system_name: {
+            'tasks': SchTASK.query.filter_by(status='WAITING').count()
+        }}
+        return data.items()

--- a/zenodo/modules/quotas/models.py
+++ b/zenodo/modules/quotas/models.py
@@ -34,7 +34,7 @@ from .signals import resource_usage_updated
 
 class Metric(object):
 
-    """Metric."""
+    """Metric interface."""
 
     metric_class = ""
     object_type = None
@@ -47,6 +47,16 @@ class Metric(object):
     @classmethod
     def all(cls):
         """Compute metrics for all resources."""
+        raise NotImplementedError()
+
+
+class Publisher(object):
+
+    """Publisher interface."""
+
+    @classmethod
+    def publish(cls, metrics):
+        """Send metrics to external service."""
         raise NotImplementedError()
 
 

--- a/zenodo/modules/quotas/publishers/__init__.py
+++ b/zenodo/modules/quotas/publishers/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.

--- a/zenodo/modules/quotas/publishers/cern.py
+++ b/zenodo/modules/quotas/publishers/cern.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Deposit disk usage metrics per user."""
+
+from __future__ import absolute_import
+
+from cernservicexml import ServiceDocument, XSLSPublisher
+from flask import current_app
+from werkzeug.utils import import_string
+
+from ..models import Publisher
+
+
+class CERNPublisher(Publisher):
+
+    """Metrics publisher for CERN XSLS service."""
+
+    @classmethod
+    def publish(cls, metrics):
+        """Publish service metrics to CERN XSLS service."""
+        api_url = current_app.config.get('QUOTAS_XSLS_API_URL')
+        service_id = current_app.config.get('QUOTAS_XSLS_SERVICE_ID')
+
+        if api_url is None:
+            raise RuntimeError("QUOTAS_XSLS_API_URL must be set.")
+        if service_id is None:
+            raise RuntimeError("QUOTAS_XSLS_SERVICE_ID must be set.")
+
+        # Create service document.
+        doc = ServiceDocument(
+            service_id,
+            contact=current_app.config.get('CFG_SITE_SUPPORT_EMAIL'),
+            webpage=current_app.config.get('CFG_SITE_URL'),
+        )
+
+        for obj in metrics:
+            doc.add_numericvalue(obj.metric, obj.value)
+
+        # Compute availability
+        try:
+            avail_imp = current_app.config.get(
+                'QUOTAS_XSLS_AVAILABILITY')
+            if avail_imp:
+                avail_func = import_string(avail_imp)
+                doc.availability = avail_func(doc)
+        except Exception:
+            current_app.logger.exception("Could not compute availability")
+
+        resp = XSLSPublisher.send(doc, api_url=api_url)
+        if resp.status_code != 200:
+            raise RuntimeError("%s did not accept service XML (status %s)" % (
+                    resp.content, resp.status_code), resp.content)


### PR DESCRIPTION
* Adds support for publishing metrics to CERN XSLS service.
  (addresses #49)

* Adds bibsched, accounts, communities and pidstore metrics.
  (addresses #141)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>