### PR TITLE
base: show types filter by default fix

### DIFF
--- a/zenodo/base/templates/search/collection.html
+++ b/zenodo/base/templates/search/collection.html
@@ -1,20 +1,20 @@
 {#
-## This file is part of Invenio.
-## Copyright (C) 2014 CERN.
-##
-## Invenio is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## Invenio is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Invenio; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# This file is part of Invenio.
+# Copyright (C) 2014, 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #}
 {%- extends "search/collection_base.html" -%}
 
@@ -71,7 +71,7 @@
                       <div class="panel-heading">
                           <a class="panel-toggle" data-toggle="collapse" data-idx="0" href="#collapse0">{% if not collection.name.startswith('user-') %}{{ _("Filter by types") }}{% else %}_("Browse by subcollections"){% endif %} <span class="pull-right show-on-collapsed"><i class="glyphicon glyphicon-chevron-right"></i></span> <span class="pull-right hide-on-collapsed"><i class="glyphicon glyphicon-chevron-down"></i></span></a>
                       </div>
-                      <div id="collapse0" class="panel-collapse">
+                      <div id="collapse0" class="panel-collapse collapse in">
                           <div class="panel-body">
                               {{ collection_tree(collection.collection_children_r, limit=2, class="nav nav-list clearfix") }}
                           </div>


### PR DESCRIPTION
* Fixes class connected with making types filter shown by default.

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>