### PR TITLE
WIP global: orcid account unlinking fix

### DIFF
--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -174,7 +174,7 @@ OAUTHCLIENT_REMOTE_APPS = dict(
         icon='',
         authorized_handler="invenio.modules.oauthclient.handlers"
                            ":authorized_signup_handler",
-        disconnect_handler="invenio.modules.oauthclient.handlers"
+        disconnect_handler="invenio.modules.oauthclient.contrib.orcid"
                            ":disconnect_handler",
         signup_handler=dict(
             info="invenio.modules.oauthclient.contrib.orcid:account_info",


### PR DESCRIPTION
* Fixes issue which left the ORCID id in UserEXT, which prevented
  users from connecting the account again after having disconnected
  it.

* TODO: Validate on production database.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>