### PR TITLE
deposit: existing doi check

### DIFF
--- a/zenodo/modules/deposit/forms.py
+++ b/zenodo/modules/deposit/forms.py
@@ -53,7 +53,7 @@ from invenio.utils.html import CFG_HTML_BUFFER_ALLOWED_TAG_WHITELIST
 
 from . import fields as zfields
 from .autocomplete import community_autocomplete
-from .validators import community_validator
+from .validators import community_validator, existing_doi_validator
 from ...legacy.utils.zenodoutils import create_doi, filter_empty_helper
 
 __all__ = ('ZenodoForm', )
@@ -487,6 +487,7 @@ class ZenodoForm(WebDepositForm):
                 prefix=CFG_DATACITE_DOI_PREFIX
             ),
             invalid_doi_prefix_validator(prefix=CFG_DATACITE_DOI_PREFIX),
+            existing_doi_validator,
         ],
         processors=[
             local_datacite_lookup

--- a/zenodo/modules/deposit/validators.py
+++ b/zenodo/modules/deposit/validators.py
@@ -79,3 +79,13 @@ def community_validator(form, field):
         for i in ids:
             if i not in found:
                 raise ValidationError("Invalid community identifier: %s" % i)
+
+
+def existing_doi_validator(form, field):
+    """Test if DOI already exists in Zenodo."""
+    from invenio.legacy.bibupload.engine import find_record_from_doi
+    from invenio.config import CFG_SITE_NAME
+
+    if field.data:
+        if find_record_from_doi(field.data) is not None:
+            raise ValidationError("DOI already exists in %s." % CFG_SITE_NAME)


### PR DESCRIPTION
* Adds check to see if DOI already exists in Zenodo in order to
  prevent bibupload from stopping.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>