### PR TITLE
installation: pyOpenSSL and ndg-httpsclient

### DIFF
--- a/base.requirements.txt
+++ b/base.requirements.txt
@@ -105,6 +105,7 @@ libmagic==1.0
 lxml==3.4.4
 mechanize==0.2.5
 msgpack-python==0.4.6
+ndg-httpsclient==0.4.0
 numpy==1.9.2
 nydus==0.11.0
 ordereddict==1.1
@@ -118,6 +119,7 @@ pyPdf==1.13
 pycparser==2.13
 pycrypto==2.6.1
 pyflakes==0.8.1
+pyOpenSSL==0.15.1
 pyoai==2.4.4
 pytest==2.7.1
 python-dateutil==2.4.2

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ install_requires = [
     "pyoai>=2.4.2",
     "awesome-slugify>=1.6",
     "cernservicexml>=0.1.2",
+    # Required for requests to connect to SSLv3 services on Linux.
+    "pyopenssl",
+    "ndg-httpsclient",
+    "pyasn1",
 ]
 
 extras_require = {


### PR DESCRIPTION
* Adds pyOpenSSL and ndg-httpsclient to requirements as they are
  needed on Linux in order to make SSLv3 requests.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>