### PR TITLE
records-ui: logo for related identifiers

### DIFF
--- a/tests/unit/records/test_views.py
+++ b/tests/unit/records/test_views.py
@@ -29,6 +29,8 @@ from __future__ import absolute_import, print_function
 from datetime import datetime, timedelta
 from flask import render_template_string
 
+from zenodo.modules.records.views import zenodo_related_links
+
 
 def test_is_valid_access_right(app):
     """Test template test."""
@@ -98,6 +100,36 @@ def test_relation_title(app):
         "{{ 'isCitedBy'|relation_title }}") == "Cited by"
     assert render_template_string(
         "{{ 'isIdenticalTo'|relation_title }}") == "isIdenticalTo"
+
+
+def test_relation_logo():
+    """Test relation logo."""
+    no_relations = {}
+    assert zenodo_related_links(no_relations) == []
+
+    github_relation = {
+        'communities': [
+            'zenodo',
+        ],
+        'related_identifiers': [
+            {
+                'scheme': 'url',
+                'relation': 'isSupplementTo',
+                'identifier': 'https://github.com/'
+                              'TaghiAliyev/BBiCat/tree/v1.0.4-alpha',
+            }
+        ],
+    }
+    assert zenodo_related_links(github_relation) == [
+        {
+            'image': 'img/github.png',
+            'link': 'https://github.com/TaghiAliyev/BBiCat/tree/v1.0.4-alpha',
+            'prefix': 'https://github.com',
+            'relation': 'isSupplementTo',
+            'scheme': 'url',
+            'text': 'Available in'
+        }
+    ]
 
 
 def test_pid_url(app):

--- a/zenodo/modules/records/config.py
+++ b/zenodo/modules/records/config.py
@@ -31,6 +31,43 @@ from speaklater import make_lazy_gettext
 
 _ = make_lazy_gettext(lambda: gettext)
 
+ZENODO_RELATION_RULES = {
+    'f1000research': [{
+        'prefix': '10.12688/f1000research',
+        'relation': 'isCitedBy',
+        'scheme': 'doi',
+        'text': 'Published in',
+        'image': 'img/f1000research.jpg',
+        }],
+    'inspire': [{
+        'prefix': 'http://inspirehep.net/record/',
+        'relation': 'isSupplementedBy',
+        'scheme': 'url',
+        'text': 'Available in',
+        'image': 'img/inspirehep.png',
+        }],
+    'briefideas': [{
+        'prefix': 'http://beta.briefideas.org/',
+        'relation': 'isIdenticalTo',
+        'scheme': 'url',
+        'text': 'Published in',
+        'image': 'img/briefideas.png',
+        }],
+    'zenodo': [{
+        'prefix': 'https://github.com',
+        'relation': 'isSupplementTo',
+        'scheme': 'url',
+        'text': 'Available in',
+        'image': 'img/github.png',
+        }, {
+        'prefix': '10.1109/JBHI',
+        'relation': 'isCitedBy',
+        'scheme': 'doi',
+        'text': 'Published in',
+        'image': 'img/ieee.jpg',
+        }],
+}
+
 ZENODO_RELATION_TYPES = [
     ('isCitedBy', _('Cited by')),
     ('cites', _('Cites')),

--- a/zenodo/modules/records/templates/zenodo_records/box/publishedin.html
+++ b/zenodo/modules/records/templates/zenodo_records/box/publishedin.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Zenodo.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Zenodo is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -31,58 +31,3 @@
 <a href="{{item.link}}"><img src="{{ url_for('static', filename=item.image) }}" class="img-thumbnail" width="100%" /></a>{% endfor %}
 </div>
 {% endif %}
-
-
-
-RULES = {
-    'f1000research': [{
-        'prefix': '10.12688/f1000research',
-        'relation': 'isCitedBy',
-        'scheme': 'doi',
-        'text': 'Published in',
-        'image': 'img/f1000research.jpg',
-    }],
-    'inspire': [{
-        'prefix': 'http://inspirehep.net/record/',
-        'relation': 'isSupplementedBy',
-        'scheme': 'url',
-        'text': 'Available in',
-        'image': 'img/inspirehep.png',
-    }],
-    'zenodo': [{
-        'prefix': 'https://github.com',
-        'relation': 'isSupplementTo',
-        'scheme': 'url',
-        'text': 'Available in',
-        'image': 'img/github.png',
-    }]
-}
-
-
-@blueprint.app_template_filter('zenodo_related_links')
-def zenodo_related_links(record):
-    def apply_rule(item, rule):
-        r = copy.deepcopy(rule)
-        r['link'] = persistentid.to_url(item['identifier'], item['scheme'])
-        return r
-
-    def match_rules(item, communities):
-        rs = []
-        for c in set(communities):
-            if c in RULES:
-                rules = RULES[c]
-                for r in rules:
-                    if item['relation'] == r['relation'] and \
-                       item['scheme'] == r['scheme'] and \
-                       item['identifier'].startswith(r['prefix']):
-                        rs.append(r)
-        return rs
-
-    ret = []
-    communities = record.get('communities', []) + \
-        record.get('provisional_communities', [])
-    for item in record.get('related_identifiers', []):
-        for r in match_rules(item, communities):
-            ret.append(apply_rule(item, r))
-
-    return ret

--- a/zenodo/modules/records/templates/zenodo_records/record_detail.html
+++ b/zenodo/modules/records/templates/zenodo_records/record_detail.html
@@ -63,6 +63,7 @@
       {%- if record.doi %}
         {{ almetric_badge(record.doi, css_class='well') }}
       {%- endif %}
+      {%- include "zenodo_records/box/publishedin.html" %}
       <div class="well metadata">
         {%- include "zenodo_records/box/info.html" %}
       </div>


### PR DESCRIPTION
* Adds logos of related identifiers to the records detail view.
  (closes #489)

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>