### PR TITLE
docker: improves image size and build speed with better caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,63 +4,67 @@
 FROM python:3.5
 MAINTAINER Zenodo <info@zenodo.org>
 
-# Node.js, bower, less, clean-css, uglify-js, requirejs
-RUN apt-get update
-RUN apt-get -qy upgrade --fix-missing --no-install-recommends
-RUN apt-get -qy install --fix-missing --no-install-recommends curl
-RUN curl -sL https://deb.nodesource.com/setup_iojs_2.x | bash -
+ARG TERM=linux
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
-RUN apt-get -qy install --fix-missing --no-install-recommends gcc git iojs
+RUN apt-get update \
+    && apt-get -qy upgrade --fix-missing --no-install-recommends \
+    && apt-get -qy install --fix-missing --no-install-recommends \
+        curl \
+    # Node.js
+    && curl -sL https://deb.nodesource.com/setup_iojs_2.x | bash - \
+    && apt-get -qy install --fix-missing --no-install-recommends \
+        iojs \
 
-# Slim down image
-RUN apt-get clean autoclean
-RUN apt-get autoremove -y
-RUN rm -rf /var/lib/{apt,dpkg}/
-RUN find /usr/share/doc -depth -type f ! -name copyright -delete
-RUN find /usr/share/doc -empty -delete
-RUN rm -rf /usr/share/man/* /usr/share/groff/* /usr/share/info/*
+    && apt-get clean autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/{apt,dpkg}/ \
+    && rm -rf /usr/share/man/* /usr/share/groff/* /usr/share/info/* \
+    && find /usr/share/doc -depth -type f ! -name copyright -delete
 
 # Basic Python and Node.js tools
-RUN pip install --upgrade pip setuptools ipython gunicorn
-RUN npm update && npm install --silent -g node-sass clean-css uglify-js requirejs
+RUN pip install --upgrade pip setuptools ipython gunicorn \
+    && npm update \
+    && npm install --silent -g node-sass clean-css uglify-js requirejs
+
 
 #
 # Zenodo specific
 #
 
-# Pre-install modules for caching
-RUN mkdir -p /usr/local/src/
-
 # Create instance/static folder
 ENV APP_INSTANCE_PATH /usr/local/var/zenodo-instance
 RUN mkdir -p ${APP_INSTANCE_PATH}
+WORKDIR /code/zenodo
+
+# Copy and install requirements. Faster build utilizing the Docker cache.
+COPY requirements*.txt /code/zenodo/
+RUN mkdir -p /usr/local/src/ \
+    && pip install -r requirements.developer.txt --src /usr/local/src
 
 # Copy source code
-COPY . /code
-WORKDIR /code
+COPY . /code/zenodo/
 
 # Install Zenodo
-RUN pip install -r requirements.developer.txt --src /usr/local/src
-RUN pip install -e .[postgresql]
-RUN python -O -m compileall .
-
-# Slim down image
-RUN rm -rf /tmp/* /var/tmp/* /var/lib/{cache,log}/ /root/.cache/*
+RUN pip install -e .[postgresql] \
+    && python -O -m compileall .
 
 # Install bower dependencies and build assets.
-RUN zenodo npm
-WORKDIR ${APP_INSTANCE_PATH}/static
-RUN npm install
-WORKDIR /code
-RUN zenodo collect -v
-RUN zenodo assets build
+RUN zenodo npm \
+    && cd ${APP_INSTANCE_PATH}/static \
+    && npm install \
+    && cd /code/zenodo \
+    && zenodo collect -v \
+    && zenodo assets build
 
-RUN adduser --uid 1000 --disabled-password --gecos '' zenodo
-RUN chown -R zenodo:zenodo /code ${APP_INSTANCE_PATH}
+RUN adduser --uid 1000 --disabled-password --gecos '' zenodo \
+    && chown -R zenodo:zenodo /code ${APP_INSTANCE_PATH}
 
-VOLUME ["/code"]
+COPY ./docker/docker-entrypoint.sh /
 
 USER zenodo
 
+VOLUME ["/code/zenodo"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["zenodo", "run", "-h", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,4 +88,4 @@ static:
   user: zenodo
   volumes:
     - "/usr/local/var/zenodo-instance/static"
-    - ".:/code"
+    - ".:/code/zenodo"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#set -e
+
+# Reinstalls zenodo. This is needed if the src is mounted into the container.
+if [ ! -d "zenodo.egg-info" ]; then
+    # Command will fail but the needed zenodo.egg-info folder is created.
+    pip install -e . > /dev/null 2>&1
+fi
+
+# https://docs.docker.com/engine/reference/builder/#entrypoint
+exec $@

--- a/requirements.developer.txt
+++ b/requirements.developer.txt
@@ -25,5 +25,3 @@
 # Pinned requirements which cannot be upgraded without breaking changes.
 -r requirements.txt
 -r requirements.devel.txt
-
--e .[all,postgresql]


### PR DESCRIPTION
* Combines RUN statements to reduce the image size.

* Adds a docker-entrypoint.

* Fixes the missing python egg folder if the local repository is fresh cloned
  and mounted as volume. (closes #479)

* Moves zenodo source to /code/zenodo.

* Removes -e . from the requirement file to support the caching of the
  requirements in the docker build process.

Signed-off-by: David Zerulla <ddaze@outlook.de>