### PR TITLE
previewer: extensions fixtures

### DIFF
--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -378,6 +378,11 @@ RECORDS_REST_FACETS = dict(
     )
 )
 
+# Previewer
+# =======
+#: Default base template for previewer extensions.
+PREVIEWER_BASE_TEMPLATE = 'zenodo_records/previewer_base_template.html'
+
 # OAI-PMH
 # =======
 #: Index to use for the OAI-PMH server.

--- a/zenodo/modules/fixtures/data/pages/api.html
+++ b/zenodo/modules/fixtures/data/pages/api.html
@@ -4,7 +4,7 @@
   <div class="panel panel-default">
     <div class="panel-heading info">
         <a class="panel-toggle collapsed" data-toggle="collapse" href="#collapse-list{{num}}">
-          <h4 id="{{anchor}}">{{title}}{% if title_small %} <small>{{title_small}}</small>{% endif %}<span class="pull-right show-on-collapsed"><i class="glyphicon glyphicon-chevron-right"></i></span><span class="pull-right hide-on-collapsed"><i class="glyphicon glyphicon-chevron-down"></i></span></h4>
+          <h4 id="{{anchor}}">{{title}}{% if title_small %} <small>{{title_small}}</small>{% endif %}<span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span><span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span></h4>
         </a>
     </div>
     <div id="collapse-list{{num}}" class="panel-collapse collapse">
@@ -54,9 +54,9 @@
         <li><a href="#restapi-http">HTTP status codes</i></a></li>
         <li><a href="#restapi-errors">Errors</i></a></li>
         <li><a href="#restapi-res">Resources</i></a></li>
-        <li><a href="#restapi-res-dep"><i class="glyphicon glyphicon-chevron-right"></i> Depositions</i></a></li>
-        <li><a href="#restapi-res-files"><i class="glyphicon glyphicon-chevron-right"></i> Deposition files</i></a></li>
-        <li><a href="#restapi-res-actions"><i class="glyphicon glyphicon-chevron-right"></i> Deposition actions</i></a></li>
+        <li><a href="#restapi-res-dep"><i class="fa fa-chevron-right"></i> Depositions</i></a></li>
+        <li><a href="#restapi-res-files"><i class="fa fa-chevron-right"></i> Deposition files</i></a></li>
+        <li><a href="#restapi-res-actions"><i class="fa fa-chevron-right"></i> Deposition actions</i></a></li>
         <li><a href="#restapi-rep">Representations</i></a></li>
         <li><a href="#restapi-changes">Changes</i></a></li>
         <li class="nav-header">OAI-PMH API</li>

--- a/zenodo/modules/records/templates/zenodo_records/box/files.html
+++ b/zenodo/modules/records/templates/zenodo_records/box/files.html
@@ -35,8 +35,8 @@
   <div class="panel-heading">
     <a class="panel-toggle" data-toggle="collapse" href="#collapseOne">
       Preview
-      <span class="pull-right show-on-collapsed"><i class="glyphicon glyphicon-chevron-right"></i></span>
-      <span class="pull-right hide-on-collapsed"><i class="glyphicon glyphicon-chevron-down"></i></span>
+      <span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span>
+      <span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span>
     </a>
   </div>
   <div id="collapseOne" class="collapse in">
@@ -47,8 +47,8 @@
   <div class="panel-heading">
     <a class="panel-toggle" data-toggle="collapse" href="#collapseTwo">
       {{ _("Files") }}
-      <span class="pull-right show-on-collapsed"><i class="glyphicon glyphicon-chevron-right"></i></span>
-      <span class="pull-right hide-on-collapsed"><i class="glyphicon glyphicon-chevron-down"></i></span>
+      <span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span>
+      <span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span>
     </a>
   </div>
   <div class="collapse in" id="collapseTwo">
@@ -93,7 +93,7 @@
     <tr class="">
         <td><a class="forcewrap" href="{{file_url}}">{{ file.filename }}</a><br /><small class="text-muted">{{file.checksum}}</small></td>
         <td class="nowrap">{{ file.size|filesizeformat }}</td>
-        <td class="nowrap"><span class="pull-right"><button class="btn preview-link btn-xs btn-default" data-filename="{{file.filename}}"><i class="fa fa-eye"></i> {{_("Preview")}}</button> <a class="btn btn-xs btn-default" href="{{file_url}}"><i class="fa fa-download"></i> {{_("Download")}}</a></span></td>
+        <td class="nowrap"><span class="pull-right">{% if file is previewable %}<button class="btn preview-link btn-xs btn-default" data-filename="{{file.filename}}"><i class="fa fa-eye"></i> {{_("Preview")}}</button>{% endif %}<a class="btn btn-xs btn-default" href="{{file_url}}"><i class="fa fa-download"></i> {{_("Download")}}</a></span></td>
       </tr>
     {%- endfor -%}
     </tbody>
@@ -107,8 +107,8 @@
   <div class="panel-heading">
     <a class="panel-toggle" data-toggle="collapse" href="#collapseTwo">
       Files
-      <span class="pull-right show-on-collapsed"><i class="glyphicon glyphicon-chevron-right"></i></span>
-      <span class="pull-right hide-on-collapsed"><i class="glyphicon glyphicon-chevron-down"></i></span>
+      <span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span>
+      <span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span>
     </a>
   </div>
   <div class="collapse in" id="collapseTwo">
@@ -130,8 +130,8 @@
   <div class="panel-heading">
     <a class="panel-toggle" data-toggle="collapse" href="#collapseTwo">
       {{ _("Files") }}
-      <span class="pull-right show-on-collapsed"><i class="glyphicon glyphicon-chevron-right"></i></span>
-      <span class="pull-right hide-on-collapsed"><i class="glyphicon glyphicon-chevron-down"></i></span>
+      <span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span>
+      <span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span>
     </a>
   </div>
   <div class="collapse in" id="collapseTwo">
@@ -146,8 +146,8 @@
   <div class="panel-heading">
     <a class="panel-toggle" data-toggle="collapse" href="#collapseTwo">
       {{ _("Files") }}
-      <span class="pull-right show-on-collapsed"><i class="glyphicon glyphicon-chevron-right"></i></span>
-      <span class="pull-right hide-on-collapsed"><i class="glyphicon glyphicon-chevron-down"></i></span>
+      <span class="pull-right show-on-collapsed"><i class="fa fa-chevron-right"></i></span>
+      <span class="pull-right hide-on-collapsed"><i class="fa fa-chevron-down"></i></span>
     </a>
   </div>
   <div class="collapse in" id="collapseTwo">

--- a/zenodo/modules/records/templates/zenodo_records/previewer_base_template.html
+++ b/zenodo/modules/records/templates/zenodo_records/previewer_base_template.html
@@ -1,0 +1,37 @@
+{#
+# This file is part of Zenodo.
+# Copyright (C) 2016 CERN.
+#
+# Zenodo is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{_('Preview')}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    {% assets "zenodo_theme_css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
+    {% block head %} {% endblock %}
+  </head>
+  <body>
+    {% block page_body %} {% endblock %}
+  </body>
+</html>

--- a/zenodo/modules/records/templates/zenodo_records/record_detail.html
+++ b/zenodo/modules/records/templates/zenodo_records/record_detail.html
@@ -85,6 +85,22 @@
 
 {%- block javascript %}{{super()}}
 <script type="text/javascript">var addthis_config = {"data_track_addressbar": true};</script>
+<script type="text/javascript">
+  $(function () {
+    $('.preview-link').on('click', function(event) {
+      $('#preview').show();
+      var filename = encodeURIComponent($(event.target).data('filename'));
+      $('#preview-iframe').attr("src","{{ url_for('invenio_records_ui.record_preview', pid_value=record.recid, filename='') }}" + filename);
+    });
+
+    var previewbutton = $('.preview-link:first');
+    if (previewbutton.html()) {
+      previewbutton.click();
+    } else {
+      $('#preview').hide();
+    }
+  });
+</script>
 <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5137aff66ad9c2a1"></script>
 <script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'></script>
 {%- endblock %}

--- a/zenodo/modules/theme/static/scss/utilities.scss
+++ b/zenodo/modules/theme/static/scss/utilities.scss
@@ -49,3 +49,18 @@
         text-align: center;
     }
 }
+
+.hide-on-collapsed {
+	display: block;
+}
+.show-on-collapsed {
+	display: none;
+}
+.panel-toggle.collapsed {
+	.hide-on-collapsed {
+		display: none;
+	}
+	.show-on-collapsed {
+		display: block;
+	}
+}

--- a/zenodo/modules/theme/templates/zenodo_theme/security/register_user.html
+++ b/zenodo/modules/theme/templates/zenodo_theme/security/register_user.html
@@ -61,7 +61,7 @@
       {{ render_field(form.profile.username, errormsg=False) }}
       {{ render_field(form.password, errormsg=False) }}
       {%- if form.password_confirm %}
-        {{ render_field(form.password_confirm, icon="glyphicon glyphicon-lock", errormsg=False) }}
+        {{ render_field(form.password_confirm, icon="fa fa-lock", errormsg=False) }}
       {%- endif %}
       {%- if form.recaptcha %}
         <div class="form-group form-group-lg"><div align="center">{{ form.recaptcha() }}</div></div>


### PR DESCRIPTION
* Updates all the glyphicons to use only font-awesome. (closes #422)

* Adds ``hide-on-collapsed`` and ``show-on-collapsed`` javascript.

* Adds the base template for previewer.

* Fixes ``Preview`` button.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>