### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,8 +26,8 @@
    :end-before: Powered by Invenio
 
 **Powered by Invenio**: Zenodo is a small layer on top of
-`Invenio <http://invenio-software.org>`_, a free software suite enabling you
-to run your own ​digital repository on the web.
+`Invenio <http://inveniosoftware.org>`_, a free software suite enabling you
+to run your own digital repository on the web.
 
 Developers's Guide
 ------------------
@@ -91,6 +91,6 @@ OpenAIRE2020.
    you must change the branding to your own.
 
    Please consider creating your own overlay to
-   `Invenio <http://invenio-software.org>`_ and look to Zenodo for inspiration.
+   `Invenio <http://inveniosoftware.org>`_ and look to Zenodo for inspiration.
    We will be happy to help you get started, just contact us on
    info@zenodo.org.

--- a/zenodo/modules/fixtures/data/pages/features.html
+++ b/zenodo/modules/fixtures/data/pages/features.html
@@ -38,7 +38,7 @@
           <img class="img-circle hide" data-src="holder.js/140x140" alt="140x140" style="width: 140px; height: 140px;">
           <h2>Safe</h2>
           <h4>— more than just a drop box!</h4>
-          <p>Your research output is stored safely for the future in same cloud infrastructure as research data from CERN's <a href="http://home.web.cern.ch/about/accelerators/large-hadron-collider">Large Hadron Collider</a> and using CERN's battle-tested repository software <a href="http://invenio-software.org">INVENIO</a>, which is used by some of the world's largest repositories such as <a href="http://inspirehep.net">INSPIRE HEP</a> and <a href="http://cds.cern.ch">CERN Document Server</a>.</p>
+          <p>Your research output is stored safely for the future in same cloud infrastructure as research data from CERN's <a href="http://home.web.cern.ch/about/accelerators/large-hadron-collider">Large Hadron Collider</a> and using CERN's battle-tested repository software <a href="http://inveniosoftware.org">INVENIO</a>, which is used by some of the world's largest repositories such as <a href="http://inspirehep.net">INSPIRE HEP</a> and <a href="http://cds.cern.ch">CERN Document Server</a>.</p>
         </div>
         <div class="col-sm-4 col-md-4">
           <img class="img-circle hide" data-src="holder.js/140x140" alt="140x140" style="width: 140px; height: 140px;">

--- a/zenodo/modules/fixtures/data/pages/policies.html
+++ b/zenodo/modules/fixtures/data/pages/policies.html
@@ -50,7 +50,7 @@ Records can be retracted from public view; however, the data files and record ar
 Metadata is licensed under CC0, except for email addresses. All metadata is exported via OAI-PMH and can be harvested.</dd>
 
 <dt>Metadata types and sources</dt>
-<dd>All metadata is stored internally in MARC according to the schema defined in <a href="http://invenio-software.org/wiki/Project/OpenAIREplus/DevelopmentRecordMarkup">http://invenio-software.org/wiki/Project/OpenAIREplus/DevelopmentRecordMarkup</a>. Metadata is exported in several standard formats such as MARCXML, Dublin Core, and DataCite Metadata Schema according to OpenAIRE Guidelines.</dd>
+<dd>All metadata is stored internally in MARC according to the schema defined in <a href="http://inveniosoftware.org/wiki/Project/OpenAIREplus/DevelopmentRecordMarkup">http://inveniosoftware.org/wiki/Project/OpenAIREplus/DevelopmentRecordMarkup</a>. Metadata is exported in several standard formats such as MARCXML, Dublin Core, and DataCite Metadata Schema according to OpenAIRE Guidelines.</dd>
 
 <dt>Language</dt>
 <dd>For textual items, English is preferred but all languages are accepted.</dd>

--- a/zenodo/modules/records/serializers/data/oai_datacite.xsl
+++ b/zenodo/modules/records/serializers/data/oai_datacite.xsl
@@ -2,7 +2,7 @@
 <!-- $Id$
 
      This file is part of Invenio.
-     Copyright (C) 2007, 2008, 2010, 2011 CERN.
+     Copyright (C) 2007, 2008, 2010, 2011, 2016 CERN.
 
      Invenio is free software; you can redistribute it and/or
      modify it under the terms of the GNU General Public License as
@@ -31,7 +31,7 @@ xmlns:marc="http://www.loc.gov/MARC21/slim"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:dc="http://purl.org/dc/elements/1.1/"
 xmlns:fn="http://cdsweb.cern.ch/bibformat/fn"
-xmlns:invenio="http://invenio-software.org/elements/1.0"
+xmlns:invenio="http://inveniosoftware.org/elements/1.0"
 xmlns:contributors="marc.contributors"
 exclude-result-prefixes="marc fn dc invenio contributors">
     <xsl:output method="xml"  indent="yes" encoding="UTF-8" omit-xml-declaration="yes"/>

--- a/zenodo/modules/records/serializers/data/oai_datacite3.xsl
+++ b/zenodo/modules/records/serializers/data/oai_datacite3.xsl
@@ -2,7 +2,7 @@
 <!-- $Id$
 
      This file is part of Invenio.
-     Copyright (C) 2007, 2008, 2010, 2011 CERN.
+     Copyright (C) 2007, 2008, 2010, 2011, 2016 CERN.
 
      Invenio is free software; you can redistribute it and/or
      modify it under the terms of the GNU General Public License as
@@ -31,7 +31,7 @@ xmlns:marc="http://www.loc.gov/MARC21/slim"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:dc="http://purl.org/dc/elements/1.1/"
 xmlns:fn="http://cdsweb.cern.ch/bibformat/fn"
-xmlns:invenio="http://invenio-software.org/elements/1.0"
+xmlns:invenio="http://inveniosoftware.org/elements/1.0"
 xmlns:contributors="marc.contributors"
 exclude-result-prefixes="marc fn dc invenio contributors">
     <xsl:output method="xml"  indent="yes" encoding="UTF-8" omit-xml-declaration="yes"/>

--- a/zenodo/modules/theme/templates/zenodo_theme/footer.html
+++ b/zenodo/modules/theme/templates/zenodo_theme/footer.html
@@ -79,7 +79,7 @@
         </div>
       </div>
       <div class="col-xs-12 col-sm-6 col-sm-pull-6 text-center-xs">
-        <p>Powered by <a href="http://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> &amp; <a href="http://invenio-software.org">Invenio</a></p>
+        <p>Powered by <a href="http://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> &amp; <a href="http://inveniosoftware.org">Invenio</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>