### PR TITLE
records: expired embargo updater task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,25 +42,27 @@ cache:
 
 services:
   - postgresql
-  - elasticsearch
   - redis
   - rabbitmq
 
 env:
   #- REQUIREMENTS=base SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/zenodo"
   #- REQUIREMENTS=release SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/zenodo"
-  - REQUIREMENTS=devel E2E="no" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/zenodo"
+  - REQUIREMENTS=devel E2E="no" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/zenodo" ES_VERSION=2.2.0
   #- REQUIREMENTS=base SQLALCHEMY_DATABASE_URI="sqlite:///tmp/zenodo.db"
   #- REQUIREMENTS=release SQLALCHEMY_DATABASE_URI="sqlite:///tmp/zenodo.db"
-  - REQUIREMENTS=devel E2E="no" SQLALCHEMY_DATABASE_URI="sqlite:///zenodo.db"
-  - REQUIREMENTS=devel E2E="yes" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/zenodo"
+  - REQUIREMENTS=devel E2E="no" SQLALCHEMY_DATABASE_URI="sqlite:///zenodo.db" ES_VERSION=2.2.0
+  - REQUIREMENTS=devel E2E="yes" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/zenodo" ES_VERSION=2.2.0
 
 python:
   - "2.7"
   - "3.4"
 
 before_install:
-  - "travis_retry pip install --upgrade pip setuptools==20.4 py"
+  - "mkdir /tmp/elasticsearch"
+  - "wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1"
+  - "/tmp/elasticsearch/bin/elasticsearch &"
+  - "travis_retry pip install --upgrade pip setuptools py"
   - "travis_retry pip install twine wheel coveralls requirements-builder"
   - "./scripts/setup-npm.sh"
   - "cat requirements.txt > .travis-base-requirements.txt"

--- a/requirements.devel.txt
+++ b/requirements.devel.txt
@@ -57,5 +57,4 @@
 -e git+https://github.com/inveniosoftware/invenio-search.git#egg=invenio-search
 -e git+https://github.com/inveniosoftware/invenio-theme.git#egg=invenio-theme
 -e git+https://github.com/inveniosoftware/invenio-userprofiles.git#egg=invenio-userprofiles
--e git+https://github.com/inveniosoftware/invenio.git#egg=invenio
 -e git+https://github.com/zenodo/zenodo-migrationkit.git#egg=zenodo-migrationkit

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+[aliases]
+test = pytest
 
 [build_sphinx]
 source-dir = docs/

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,8 @@
 """Zenodo - Research. Shared."""
 
 import os
-import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
@@ -37,6 +35,7 @@ tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
     'isort>=4.2.2',
+    'mock>=1.3.0',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
@@ -72,6 +71,7 @@ for name, reqs in extras_require.items():
 
 setup_requires = [
     'Babel>=1.3',
+    'pytest-runner>=2.7.0',
 ]
 
 install_requires = [
@@ -108,7 +108,6 @@ install_requires = [
     'invenio-search',
     'invenio-theme',
     'invenio-userprofiles',
-    'invenio>=3.0.0a1,<3.1.0',
     'jsonref>=0.1',
     'marshmallow>=2.5.0',
     'python-slugify>=1.2.0',
@@ -117,36 +116,6 @@ install_requires = [
 
 packages = find_packages()
 
-
-class PyTest(TestCommand):
-    """PyTest Test."""
-
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        """Init pytest."""
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-        try:
-            from ConfigParser import ConfigParser
-        except ImportError:
-            from configparser import ConfigParser
-        config = ConfigParser()
-        config.read('pytest.ini')
-        self.pytest_args = config.get('pytest', 'addopts').split(' ')
-
-    def finalize_options(self):
-        """Finalize pytest."""
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        """Run tests."""
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 # Get the version string. Cannot be done with import!
 g = {}
@@ -227,5 +196,4 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Development Status :: 3 - Alpha',
     ],
-    cmdclass={'test': PyTest},
 )

--- a/zenodo/modules/fixtures/data/records.json
+++ b/zenodo/modules/fixtures/data/records.json
@@ -6043,7 +6043,8 @@
       {
         "json": {
           "modification_date": "2015-11-19T14:27:29",
-          "access_right": "open",
+          "access_right": "embargoed",
+          "embargo_date": "2016-04-01T01:01:01",
           "upload_type": {
             "type": "software"
           },
@@ -6206,7 +6207,8 @@
               "name": "Belleman, J\u00e9r\u00f4me"
             }
           ],
-          "access_right": "open"
+          "access_right": "embargoed",
+          "embargo_date": "2016-03-01T01:02:03"
         },
         "modification_datetime": "2014-03-10T17:38:58+00:00",
         "marcxml": ""


### PR DESCRIPTION
* Adds a task to change access right of embargoed records after the
  embargo date has passed. (closes #488)

Reviewed-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>

(closes #506)