### PR TITLE
Secure DOIs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,7 @@ Credits
   * Jiri Kuncar
   * João Gonçalves
   * Krzysztof Nowak
+  * Katrin Leinweber
   * Leonardo Rossi
   * Odd Magnus Trondrud
   * Sami Hiltunen

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -252,7 +252,7 @@ def grant_record(db, funder_record):
     """Create a funder record."""
     grant = Record.create(dict(
         internal_id='10.13039/501100000780::282896',
-        funder={'$ref': 'http://dx.doi.org/10.13039/501100000780'},
+        funder={'$ref': 'https://doi.org/10.13039/501100000780'},
         identifiers=dict(
             eurepo='info:eu-repo/grantAgreement/EC/FP7/282896',
         ),

--- a/tests/unit/records/test_bibtex_serializer.py
+++ b/tests/unit/records/test_bibtex_serializer.py
@@ -45,7 +45,7 @@ def test_serializer(bibtex_records):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == serializer.serialize(record=test_record, pid=1)
     results = {
@@ -193,7 +193,7 @@ def test_get_school(bibtex_records):
 def test_get_url(bibtex_records):
     """Test."""
     (record_good, record_bad, record_empty, test_record) = bibtex_records
-    url = "http://dx.doi.org/" + test_record['doi']
+    url = "https://doi.org/" + test_record['doi']
     assert url == record_good._get_url()
     assert "" == record_empty._get_url()
 
@@ -220,7 +220,7 @@ def test_format_article(full_record):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -239,7 +239,7 @@ def test_format_book(full_record):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -255,7 +255,7 @@ def test_format_booklet(full_record):
               """  address      = {Staszkowka},\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -271,7 +271,7 @@ def test_format_inbook(full_record):
               """  year         = 2014,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -291,7 +291,7 @@ def test_format_inproceedings(full_record):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -309,7 +309,7 @@ def test_format_inproceedings(full_record):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -326,7 +326,7 @@ def test_format_inproceedings(full_record):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -343,7 +343,7 @@ def test_format_proceedings(full_record):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -360,7 +360,7 @@ def test_format_manual(full_record):
               """  year         = 2014,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -377,7 +377,7 @@ def test_format_manual(full_record):
               """  year         = 2014,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -402,7 +402,7 @@ def test_format_manual(full_record):
               "  year         = 2014,\n"
               "  note         = {notes},\n"
               "  doi          = {10.1234/foo.bar},\n"
-              "  url          = {http://dx.doi.org/10.1234/foo.bar}\n"
+              "  url          = {https://doi.org/10.1234/foo.bar}\n"
               "}")
     assert bibtex == Bibtex(full_record).format()
 
@@ -415,7 +415,7 @@ def test_format_manual(full_record):
               """  year         = 2014,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -433,7 +433,7 @@ def test_format_thesis(full_record):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -447,7 +447,7 @@ def test_format_thesis(full_record):
               """  month        = feb,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -463,7 +463,7 @@ def test_format_unpublished(full_record):
               """  month        = feb,\n"""
               """  year         = 2014,\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
     full_record['resource_type']['subtype'] = 'workingpaper'
@@ -481,7 +481,7 @@ def test_format_default_type(full_record):
               """  year         = 2014,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()
 
@@ -498,6 +498,6 @@ def test_format_publication_default(full_record):
               """  year         = 2014,\n"""
               """  note         = {notes},\n"""
               """  doi          = {10.1234/foo.bar},\n"""
-              """  url          = {http://dx.doi.org/10.1234/foo.bar}\n"""
+              """  url          = {https://doi.org/10.1234/foo.bar}\n"""
               """}""")
     assert bibtex == Bibtex(full_record).format()

--- a/tests/unit/records/test_views.py
+++ b/tests/unit/records/test_views.py
@@ -138,7 +138,7 @@ def test_relation_logo():
 def test_pid_url(app):
     """Test pid_url."""
     assert render_template_string(
-        "{{ '10.123/foo'|pid_url }}") == "http://dx.doi.org/10.123/foo"
+        "{{ '10.123/foo'|pid_url }}") == "https://doi.org/10.123/foo"
     assert render_template_string(
         "{{ 'asfasdf'|pid_url }}") == ""
     assert render_template_string(

--- a/zenodo/modules/fixtures/data/grants.json
+++ b/zenodo/modules/fixtures/data/grants.json
@@ -5,7 +5,7 @@
     "code": "502084",
     "enddate": "2008-08-31",
     "funder": {
-      "$ref": "http://dx.doi.org/10.13039/501100000780"
+      "$ref": "https://doi.org/10.13039/501100000780"
     },
     "identifiers": {
       "eurepo": "info:eu-repo/grantAgreement/EC/FP6/502084/"

--- a/zenodo/modules/fixtures/data/pages/api.html
+++ b/zenodo/modules/fixtures/data/pages/api.html
@@ -1445,7 +1445,7 @@ r = requests.post("{{BASE_URL}}api/deposit/depositions/1234/actions/discard?acce
     <p>Example:</p>
     <pre>[
   {'relation': 'isSupplementTo', 'identifier':'10.1234/foo'},
-  {'relation': 'cites', 'identifier':'http://dx.doi.org/10.1234/bar'}
+  {'relation': 'cites', 'identifier':'https://doi.org/10.1234/bar'}
 ]</pre><p>Note the identifier type (e.g. DOI) is automatically detected, and used to validate and normalize the identifier into a standard form.</p></td>
 </tr>
 <tr>

--- a/zenodo/modules/records/serializers/bibtex.py
+++ b/zenodo/modules/records/serializers/bibtex.py
@@ -473,7 +473,7 @@ class Bibtex(object):
 
     def _get_url(self):
         """Return the WWW address."""
-        return "http://dx.doi.org/%s" % self.record['doi'] \
+        return "https://doi.org/%s" % self.record['doi'] \
             if "doi" in self.record else ""
 
     def _get_volume(self):

--- a/zenodo/modules/records/templates/zenodo_records/box/info.html
+++ b/zenodo/modules/records/templates/zenodo_records/box/info.html
@@ -56,20 +56,20 @@
                 <h4>Zenodo DOI Badge</h4>
 
                 <h4><small>Markdown</small></h4><h4>
-                <pre>[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.32481.svg)](http://dx.doi.org/10.5281/zenodo.32481)</pre>
+                <pre>[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.32481.svg)](https://doi.org/10.5281/zenodo.32481)</pre>
 
                 </h4><h4><small>reStructedText</small></h4><h4>
                 <pre>.. image:: https://zenodo.org/badge/doi/10.5281/zenodo.32481.svg
-     :target: http://dx.doi.org/10.5281/zenodo.32481</pre>
+     :target: https://doi.org/10.5281/zenodo.32481</pre>
 
                 </h4><h4><small>HTML</small></h4><h4>
-                <pre>&lt;a href="http://dx.doi.org/10.5281/zenodo.32481"&gt;&lt;img src="https://zenodo.org/badge/doi/10.5281/zenodo.32481.svg" alt="10.5281/zenodo.32481"&gt;&lt;/a&gt;</pre>
+                <pre>&lt;a href="https://doi.org/10.5281/zenodo.32481"&gt;&lt;img src="https://zenodo.org/badge/doi/10.5281/zenodo.32481.svg" alt="10.5281/zenodo.32481"&gt;&lt;/a&gt;</pre>
 
                 </h4><h4><small>Image URL</small></h4><h4>
                 <pre>https://zenodo.org/badge/doi/10.5281/zenodo.32481.svg</pre>
 
                 </h4><h4><small>DOI URL</small></h4><h4>
-                <pre>http://dx.doi.org/10.5281/zenodo.32481</pre>
+                <pre>https://doi.org/10.5281/zenodo.32481</pre>
               </h4></div>
             </div>
           </div>


### PR DESCRIPTION
The DOI foundation has [stopped listing the `dx` resolver as "preferred", and started to support HTTPS](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).