### PR TITLE
display: alternate identifiers and keywords

### DIFF
--- a/zenodo/modules/records/templates/zenodo_records/box/info.html
+++ b/zenodo/modules/records/templates/zenodo_records/box/info.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Zenodo.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Zenodo is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -121,6 +121,21 @@
     {%- endfor %}
     </dd>
   {%- endfor %}
+
+  {%- if record.alternate_identifiers %}
+    <dt>{{ _('Alternate identifiers') }}:</dt>
+    <dd>
+    {%- for alt_id in record.alternate_identifiers %}
+      {%- set alt_url = alt_id.identifier|pid_url(scheme=alt_id.scheme) %}
+      {%- if alt_url %}
+        <a href="{{alt_url}}">{{alt_id.identifier}}</a>
+      {%- else %}
+        <i>{{alt_id.identifier}}</i> ({{alt_id.scheme|upper}})
+      {%- endif %}
+      {%- if not loop.last %}, {% endif %}
+    {%- endfor %}
+    </dd>
+  {%- endif %}
 
   {#- FIXME: Communities -#}
 

--- a/zenodo/modules/theme/static/scss/record.scss
+++ b/zenodo/modules/theme/static/scss/record.scss
@@ -1,5 +1,5 @@
 // This file is part of Zenodo.
-// Copyright (C) 2015 CERN.
+// Copyright (C) 2015, 2016 CERN.
 //
 // Zenodo is free software; you can redistribute it
 // and/or modify it under the terms of the GNU General Public License as
@@ -29,6 +29,14 @@
   dd {
     padding-left: 10px;
     margin-bottom: 4px;
+
+    .label {
+      display: inline-block;
+      margin-top: 2px;
+      line-height: inherit;
+      text-align: left;
+      white-space: normal;
+    }
   }
 }
 


### PR DESCRIPTION
* Adds alternate identifiers to the records UI info box.

* Fixes spacing issue for alternate identifiers. (closes #490)

* Fixes long keyword linebreaks. (closes #467)

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>