### PR TITLE
global: addition of legacy redirections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,7 @@ setup(
         'invenio_base.blueprints': [
             'zenodo_deposit = zenodo.modules.deposit.views:blueprint',
             'zenodo_frontpage = zenodo.modules.frontpage.views:blueprint',
+            'zenodo_redirector = zenodo.modules.redirector.views:blueprint',
             'zenodo_search_ui = zenodo.modules.search_ui.views:blueprint',
             'zenodo_theme = zenodo.modules.theme.views:blueprint',
         ],

--- a/tests/unit/redirector/test_redirection.py
+++ b/tests/unit/redirector/test_redirection.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Zenodo.
+# Copyright (C) 2016 CERN.
+#
+# Zenodo is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Zenodo redirector tests."""
+
+from __future__ import absolute_import, print_function
+
+from flask import url_for
+
+try:
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
+
+
+def compare_url(url, expected):
+    """Compares two urls replying if they are the same."""
+    return (parse_qs(url) == parse_qs(expected) and
+            urlparse(url).path == urlparse(expected).path)
+
+
+def check_redirection(response, expected_url):
+    """."""
+    assert response.status_code == 302
+    assert any(k == 'Location' and compare_url(v, expected_url)
+               for k, v in response.headers)
+
+
+def test_redirection_community(app_client):
+    """Check the redirection using a direct translation."""
+    url_redirection = url_for('invenio_communities.detail', community_id=1,
+                              _external=True)
+
+    response = app_client.get('/collection/user-1')
+    check_redirection(response, url_redirection)
+
+
+def test_redirection_community_search(app_client):
+    """Check the redirection using a direct translation."""
+    url_redirection = url_for('invenio_communities.search', community_id=1,
+                              _external=True)
+
+    response = app_client.get('/search?cc=user-1')
+    check_redirection(response, url_redirection)
+
+    # Query translation
+    url_redirection = url_for('invenio_communities.search', community_id=1,
+                              q='test', _external=True)
+
+    response = app_client.get('/search?cc=user-1&p=test')
+    check_redirection(response, url_redirection)
+
+
+def test_redirection_communities_provisional_user(app_client):
+    """Check the redirection using a direct translation."""
+    url_redirection = url_for('invenio_communities.curate', community_id=1,
+                              _external=True)
+
+    response = app_client.get('/search?cc=provisional-user-1')
+    check_redirection(response, url_redirection)
+
+    # Query translation
+    url_redirection = url_for('invenio_communities.curate', community_id=1,
+                              q='test', _external=True)
+
+    response = app_client.get('/search?cc=provisional-user-1&p=test')
+    check_redirection(response, url_redirection)
+
+
+def test_redirection_communities_about(app_client):
+    """Check the redirection using a direct translation."""
+    url_redirection = url_for('invenio_communities.about', community_id=1,
+                              _external=True)
+
+    response = app_client.get('/communities/about/1/')
+    check_redirection(response, url_redirection)
+
+
+def test_redirection_collections_type(app_client):
+    """Check the redirection using a direct translation."""
+    # Type
+    url_redirection = url_for('invenio_search_ui.search', type='videos',
+                              _external=True)
+    response = app_client.get('/collection/videos')
+    check_redirection(response, url_redirection)
+
+    # Type and subtype
+    url_redirection = url_for('invenio_search_ui.search', type='publications',
+                              subtype='deliverable', _external=True)
+    response = app_client.get('/collection/deliverable')
+    check_redirection(response, url_redirection)
+
+
+def test_redirection_collections_search(app_client):
+    """Check the redirection using a direct translation."""
+    # Type
+    url_redirection = url_for('invenio_search_ui.search', type='videos',
+                              _external=True)
+    response = app_client.get('/search?cc=videos')
+    check_redirection(response, url_redirection)
+
+    # Type and subtype
+    url_redirection = url_for('invenio_search_ui.search', type='publications',
+                              subtype='deliverable', _external=True)
+    response = app_client.get('/search?cc=deliverable')
+    check_redirection(response, url_redirection)
+
+    # Query translation
+    url_redirection = url_for('invenio_search_ui.search', type='publications',
+                              subtype='deliverable', q='test', _external=True)
+
+    response = app_client.get('/search?cc=deliverable&p=test')
+    check_redirection(response, url_redirection)
+
+
+def test_redirection_search_behaviour(app_client):
+    """Check the behaviour of url_for using invenio_search_ui.index."""
+    # Empty url
+    response = app_client.get(url_for('invenio_search_ui.search'))
+    assert response.status_code == 200
+    assert '<invenio-search' in response.get_data(as_text=True)
+
+    # Query string
+    response = app_client.get(url_for('invenio_search_ui.search',
+                                      page=1, size=20, q='Aa'))
+    assert response.status_code == 200
+    assert '<invenio-search' in response.get_data(as_text=True)

--- a/zenodo/modules/redirector/__init__.py
+++ b/zenodo/modules/redirector/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Zenodo.
+# Copyright (C) 2016 CERN.
+#
+# Zenodo is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Zenodo redirector."""
+
+from __future__ import absolute_import, print_function

--- a/zenodo/modules/redirector/config.py
+++ b/zenodo/modules/redirector/config.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Zenodo.
+# Copyright (C) 2016 CERN.
+#
+# Zenodo is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Configuration for Zenodo Redirector."""
+
+from __future__ import absolute_import, print_function
+
+ZENODO_TYPE_SUBTYPE_LEGACY = {
+    'publications': ('publications', None),
+    'books': ('publications', 'books'),
+    'books-sections': ('publications', 'sections'),
+    'conference-papers': ('publications', 'conference-papers'),
+    'journal-articles': ('publications', 'journal-articles'),
+    'patents': ('publications', 'patents'),
+    'preprints': ('publications', 'preprints'),
+    'deliverable': ('publications', 'deliverable'),
+    'milestone': ('publications', 'milestone'),
+    'proposal': ('publications', 'proposal'),
+    'reports': ('publications', 'reports'),
+    'theses': ('publications', 'theses'),
+    'technical-notes': ('publications', 'technical-notes'),
+    'working-papers': ('publications', 'working-papers'),
+    'other-publications': ('publications', 'other'),
+
+    'posters': ('posters', None),
+
+    'presentations': ('presentations', None),
+
+    'datasets': ('datasets', None),
+
+    'images': ('images', None),
+    'figures': ('images', 'figures'),
+    'drawings': ('images', 'drawings'),
+    'diagrams': ('images', 'diagrams'),
+    'photos': ('images', 'photos'),
+    'other-images': ('images', 'other'),
+
+    'videos': ('videos', None),
+
+    'software': ('software', None),
+
+    'lessons': ('lessons', None),
+}

--- a/zenodo/modules/redirector/views.py
+++ b/zenodo/modules/redirector/views.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Zenodo redirector."""
+
+from __future__ import absolute_import, print_function
+
+from flask import Blueprint, redirect, request, url_for
+from invenio_search_ui.views import search as search_ui_search
+
+from .config import ZENODO_TYPE_SUBTYPE_LEGACY
+
+blueprint = Blueprint(
+    'zenodo_redirector',
+    __name__,
+    template_folder='templates',
+    static_folder='static',
+)
+
+
+@blueprint.record_once
+def configure_search_handler(blueprint_setup):
+    """Update the search endpoint."""
+    blueprint_setup.app.view_functions[
+        'invenio_search_ui.search'] = search_handler
+
+
+# https://zenodo.org/collection/user-<id>
+# https://zenodo.org/communities/<id>/
+@blueprint.route('/collection/user-<id>')
+def community_redirect(id):
+    """Redirect from the old community details to the new one."""
+    values = request.args.to_dict()
+    values['community_id'] = id
+    return redirect(url_for('invenio_communities.detail', **values))
+
+
+# https://zenodo.org/communities/about/<id>/
+# https://zenodo.org/communities/<id>/about/
+@blueprint.route('/communities/about/<id>/')
+def communities_about_redirect(id):
+    """."""
+    values = request.args.to_dict()
+    values['community_id'] = id
+    return redirect(url_for('invenio_communities.about', **values))
+
+
+# https://zenodo.org/collection/<type>
+# https://zenodo.org/search?type=<general type>&subtype=<sub type>
+@blueprint.route('/collection/<type>')
+def collections_type_redirect(type):
+    """."""
+    values = request.args.to_dict()
+
+    type, subtype = ZENODO_TYPE_SUBTYPE_LEGACY.get(type, ('', None))
+    values['type'] = type
+    if subtype:
+        values['subtype'] = subtype
+
+    return redirect(url_for('invenio_search_ui.search', **values))
+
+
+def search_handler():
+    """."""
+    if 'cc' in request.args:
+        if request.args.get('cc', '').startswith('user-'):
+            return community_search_redirect()
+        elif request.args.get('cc', '').startswith('provisional-user-'):
+            return communities_provisional_user_redirect()
+        else:
+            return collections_search_redirect()
+    else:
+        return search_ui_search()
+
+
+# https://zenodo.org/search?ln=en&cc=user-<id>&p=<query>&action_search=
+# https://zenodo.org/communities/<id>/search?q=<query>
+def community_search_redirect():
+    """Redirect from the old community search to the new one."""
+    values = request.args.to_dict()
+
+    values['community_id'] = values.pop('cc')[5:]  # len('user-') == 5
+
+    if 'p' in values:
+        values['q'] = values.pop('p')
+
+    return redirect(url_for('invenio_communities.search', **values))
+
+
+# https://zenodo.org/search?cc=provisional-user-<id>&p=<query>
+# https://zenodo.org/communities/<id>/curate/?q=<query>
+def communities_provisional_user_redirect():
+    """Redirect from the old communities provisional search to the new one."""
+    values = request.args.to_dict()
+
+    # len('provisional-user-') == 17
+    values['community_id'] = values.pop('cc')[17:]
+
+    if 'p' in values:
+        values['q'] = values.pop('p')
+
+    return redirect(url_for('invenio_communities.curate', **values))
+
+
+# https://zenodo.org/search?ln=en&cc=<type>
+# https://zenodo.org/search?type=<general type>&subtype=<sub type>
+def collections_search_redirect():
+    """."""
+    values = request.args.to_dict()
+
+    type, subtype = ZENODO_TYPE_SUBTYPE_LEGACY.get(
+        values.pop('cc'), ('', None))
+    values['type'] = type
+    if subtype:
+        values['subtype'] = subtype
+
+    if 'p' in values:
+        values['q'] = values.pop('p')
+
+    return redirect(url_for('invenio_search_ui.search', **values))


### PR DESCRIPTION
* Adds the redirections needed in order to make the previous Zenodo
  links compatibles. (closes #427)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>