### PR TITLE
jsonschemas: related identifier vocabulary extension

### DIFF
--- a/tests/unit/records/test_views.py
+++ b/tests/unit/records/test_views.py
@@ -106,7 +106,7 @@ def test_relation_title(app):
     assert render_template_string(
         "{{ 'isCitedBy'|relation_title }}") == "Cited by"
     assert render_template_string(
-        "{{ 'isIdenticalTo'|relation_title }}") == "isIdenticalTo"
+        "{{ 'nonExistingRelation'|relation_title }}") == "nonExistingRelation"
 
 
 def test_relation_logo():

--- a/zenodo/modules/records/config.py
+++ b/zenodo/modules/records/config.py
@@ -76,7 +76,12 @@ ZENODO_RELATION_TYPES = [
     ('references', _('References')),
     ('isReferencedBy', _('Referenced by')),
     ('isNewVersionOf', _('Previous versions')),
-    ('isPreviousVersionOf', _('New versions'))
+    ('isPreviousVersionOf', _('New versions')),
+    ('isPartOf', _('Part of')),
+    ('hasPart', _('Has part')),
+    ('compiles', _('Compiles')),
+    ('isCompiledBy', _('Compiled by')),
+    ('isIdenticalTo', _('Identical to')),
 ]
 
 ZENODO_LOCAL_DOI_PREFIXES = []


### PR DESCRIPTION
* Adds missing relation types for related identifiers.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>