### PR TITLE
tests: fixture of redirection test

### DIFF
--- a/tests/unit/redirector/test_redirection.py
+++ b/tests/unit/redirector/test_redirection.py
@@ -35,16 +35,17 @@ except ImportError:
 
 
 def compare_url(url, expected):
-    """Compares two urls replying if they are the same."""
-    return (parse_qs(url) == parse_qs(expected) and
+    """Compare two urls replying if they are the same."""
+    def get_querystring_dict(url):
+        return parse_qs(urlparse(url).query)
+    return (get_querystring_dict(url) == get_querystring_dict(expected) and
             urlparse(url).path == urlparse(expected).path)
 
 
 def check_redirection(response, expected_url):
     """."""
     assert response.status_code == 302
-    assert any(k == 'Location' and compare_url(v, expected_url)
-               for k, v in response.headers)
+    assert compare_url(response.headers['Location'], expected_url)
 
 
 def test_redirection_community(app_client, db):


### PR DESCRIPTION
* Fixes the random fail test occuring in the redirection test because
  of the querystring order.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>