### PR TITLE
citeproc: handle citeproc errors

### DIFF
--- a/zenodo/modules/records/templates/zenodo_records/box/share.html
+++ b/zenodo/modules/records/templates/zenodo_records/box/share.html
@@ -35,7 +35,14 @@
   <!-- AddThis Button END -->
   <h4>{{_('Cite as')}}</h4>
   <div id='invenio-csl'>
-    <invenio-csl ng-init="vm.citationResult='{{record|citation(pid, style='apa')}}'">
+    {% set citation_result = record|citation(pid, style='apa') %}
+    <invenio-csl
+      {%- if citation_result %}
+        ng-init="vm.citationResult = '{{citation_result}}'"
+      {%- else %}
+        ng-init="vm.error = '{{_('Your record could not be processed by the citation formatter')}}'"
+      {%- endif %}
+    >
       <invenio-csl-citeproc
        endpoint="{{ config.CSL_RECORDS_API_ENDPOINT ~ pid.pid_value }}"
        template="{{ url_for('static', filename=config.CSL_JSTEMPLATE_CITEPROC) }}"></invenio-csl-citeproc>

--- a/zenodo/modules/records/views.py
+++ b/zenodo/modules/records/views.py
@@ -235,7 +235,13 @@ def citation(record, pid, style=None, ln=None):
     """Render citation for record according to style and language."""
     locale = ln or current_i18n.language
     style = style or 'science'
-    return citeproc_v1.serialize(pid, record, style=style, locale=locale)
+    try:
+        return citeproc_v1.serialize(pid, record, style=style, locale=locale)
+    except Exception:
+        current_app.logger.exception(
+            'Citation formatting for record {0} failed.'
+            .format(str(record.id)))
+        return None
 
 
 @blueprint.app_template_filter('pid_url')


### PR DESCRIPTION
* Returns None when catching citation formatting errors. (closes #775)

* Displays an appropriate citeproc error message in the record's detail
  view.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>