### PR TITLE
Fix grammar mistake on the sign up page

### DIFF
--- a/zenodo/modules/theme/templates/zenodo_theme/security/register_user.html
+++ b/zenodo/modules/theme/templates/zenodo_theme/security/register_user.html
@@ -86,7 +86,7 @@
     <div class="col-sm-6 col-sm-pull-6 sign-up sign-up-benefits">
       {%- block signup_benefits %}
       <h4>{{_('Citeable. Discoverable.')}}</h4>
-      <p>{{_('Uploads gets a Digital Object Identifier (DOI) to make them easily and uniquely citeable.')}}</p>
+      <p>{{_('Uploads get a Digital Object Identifier (DOI) to make them easily and uniquely citeable.')}}</p>
       <h4>{{_('Communities')}}</h4>
       <p>{{_('Accept or reject uploads to your own community (e.g workshops, EU projects, institutions or entire disciplines).')}}</p>
       {%- endblock signup_benefits %}


### PR DESCRIPTION
"Uploads gets a DOI" -> "Uploads get a DOI"