### PR TITLE
Fix nginx configuration error

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -60,8 +60,8 @@ http {
         text/vnd.rim.location.xloc
         text/vtt
         text/x-component
-        text/x-cross-domain-policy;
-        text/xml
+        text/x-cross-domain-policy
+        text/xml;
     gzip_vary on;
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
A ";" is misplaced.
Docker frontend container will not start with this problem.