### PR TITLE
deposit: published record fields preservation fix

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -23,8 +23,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-pydocstyle zenodo tests && \
-isort -rc -c -df . && \
+pydocstyle zenodo tests docs && \
+isort -rc -c -df && \
 check-manifest --ignore ".travis-*,docs/_build*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 py.test tests/unit/ && \

--- a/tests/unit/deposit/test_api_files.py
+++ b/tests/unit/deposit/test_api_files.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import, print_function
 
 import json
 
-from invenio_files_rest.models import MultipartObject
 from invenio_search import current_search
 from six import BytesIO
 

--- a/tests/unit/deposit/test_deposit_api.py
+++ b/tests/unit/deposit/test_deposit_api.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Test Zenodo Deposit API."""
+
+from __future__ import absolute_import, print_function
+
+from copy import deepcopy
+
+from helpers import publish_and_expunge
+
+
+def test_basic_deposit_edit(app, db, communities, deposit, deposit_file):
+    """Test simple deposit publishing."""
+    deposit = publish_and_expunge(db, deposit)
+    pid, record = deposit.fetch_published()
+    initial_oai = deepcopy(record['_oai'])
+
+    # Create some potential corruptions to protected fields
+    deposit = deposit.edit()
+    deposit['_files'][0]['bucket'] = record['_buckets']['deposit']
+    deposit['_oai'] = {}
+    deposit = publish_and_expunge(db, deposit)
+    pid, record = deposit.fetch_published()
+    assert record['_oai'] == initial_oai
+    assert record['_files'][0]['bucket'] == record['_buckets']['record']

--- a/zenodo/modules/deposit/api.py
+++ b/zenodo/modules/deposit/api.py
@@ -327,7 +327,13 @@ class ZenodoDeposit(Deposit):
             new_owned_comms |
             set(auto_added)
         )
-        record = super(ZenodoDeposit, self)._publish_edited()
+        edited_record = super(ZenodoDeposit, self)._publish_edited()
+
+        # Preserve some of the previously published record fields
+        preserve_record_fields = ['_files', '_oai', '_buckets', '_internal']
+        for k in preserve_record_fields:
+            if k in record:
+                edited_record[k] = record[k]
 
         # Add communities entry to deposit (self)
         self['communities'] = sorted(set(self.get('communities', []) +
@@ -336,12 +342,12 @@ class ZenodoDeposit(Deposit):
             del self['communities']
 
         # Add communities entry to record
-        record['communities'] = sorted(list(new_rec_comms))
-        record = self._sync_oaisets_with_communities(record)
-        if not record['communities']:
-            del record['communities']
-        zenodo_doi_updater(record.id, record)
-        return record
+        edited_record['communities'] = sorted(list(new_rec_comms))
+        edited_record = self._sync_oaisets_with_communities(edited_record)
+        if not edited_record['communities']:
+            del edited_record['communities']
+        zenodo_doi_updater(edited_record.id, edited_record)
+        return edited_record
 
     def validate_publish(self):
         """Validate deposit."""


### PR DESCRIPTION
Fixes an issue with internal metadata fields such as _oai, _files getting overwritten after editing of a pre-migration record.