### PR TITLE
docker: npm package installation fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,13 @@ RUN apt-get update \
     && rm -rf /usr/share/man/* /usr/share/groff/* /usr/share/info/* \
     && find /usr/share/doc -depth -type f ! -name copyright -delete
 
-# Basic Python and Node.js tools
+# Basic Python tools
 RUN pip install --upgrade pip setuptools ipython \
-    && pip install uwsgi \
-    && npm update \
-    && npm install --silent -g node-sass clean-css uglify-js requirejs
+    && pip install uwsgi
+
+# NPM
+COPY ./scripts/setup-npm.sh /tmp
+RUN /tmp/setup-npm.sh
 
 #
 # Zenodo specific


### PR DESCRIPTION
* Fixes look-and-feel of the Docker-built Zenodo site by installing appropriate
  npm package versions.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>