### PR TITLE
docker: Elasticsearch mapper-attachments plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,13 @@ RUN apt-get update \
     && rm -rf /usr/share/man/* /usr/share/groff/* /usr/share/info/* \
     && find /usr/share/doc -depth -type f ! -name copyright -delete
 
-# Basic Python and Node.js tools
+# Basic Python tools
 RUN pip install --upgrade pip setuptools ipython \
-    && pip install uwsgi \
-    && npm update \
-    && npm install --silent -g node-sass clean-css uglify-js requirejs
+    && pip install uwsgi
+
+# NPM
+COPY ./scripts/setup-npm.sh /tmp
+RUN /tmp/setup-npm.sh
 
 #
 # Zenodo specific

--- a/docker/es/Dockerfile
+++ b/docker/es/Dockerfile
@@ -1,2 +1,3 @@
 FROM elasticsearch:2.3
 RUN plugin install royrusso/elasticsearch-HQ/2.0.3
+RUN plugin install mapper-attachments


### PR DESCRIPTION
* Installs Elasticsearch mapper-attachments plugin, fixing loading of demo
  records.
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
