### PR TITLE
deposit: unicode sanitization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ install_requires = [
     'Flask-Cache>=0.13.1',
     'Flask-Debugtoolbar>=0.10.0',
     'Flask-Konch>=1.1.0',
+    'ftfy>=4.2.0,<5'
     'idutils>=0.2.3',
     'invenio-access>=1.0.0a11',
     'invenio-accounts>=1.0.0b1',

--- a/tests/unit/records/test_schemas_legacyjson_load.py
+++ b/tests/unit/records/test_schemas_legacyjson_load.py
@@ -790,3 +790,23 @@ def test_legacyjson_to_record_translation(app, db, es, grant_record,
     ZenodoDeposit.create(
         legacyjson.LegacyRecordSchemaV1(strict=True).load(test_data).data
     ).validate()
+
+
+invalid_unicode_chars_params = (
+    # Zero-width space
+    u'\u200b',
+    # Line Tabulation
+    u'\u000b',
+    # Escape
+    u'\u001b',
+    # Cancel
+    u'\u0018',
+)
+
+
+@pytest.mark.parametrize('unicode_char', invalid_unicode_chars_params)
+def test_invalid_unicode_characters(app, db, es, grant_record, license_record,
+                                    location, unicode_char):
+    assert (legacyjson.LegacyMetadataSchemaV1(strict=True).load(
+            d(description=u'Invalid character: [{}]'.format(unicode_char)))
+            .data['description'] == u'Invalid character: []')

--- a/zenodo/modules/records/serializers/fields/doi.py
+++ b/zenodo/modules/records/serializers/fields/doi.py
@@ -30,8 +30,10 @@ import idutils
 from flask_babelex import lazy_gettext as _
 from marshmallow import fields
 
+from .sanitizedunicode import SanitizedUnicode
 
-class DOI(fields.String):
+
+class DOI(SanitizedUnicode):
     """Special DOI field."""
 
     default_error_messages = {

--- a/zenodo/modules/records/serializers/fields/html.py
+++ b/zenodo/modules/records/serializers/fields/html.py
@@ -27,10 +27,11 @@
 from __future__ import absolute_import, print_function
 
 import bleach
-from marshmallow import fields
+
+from .sanitizedunicode import SanitizedUnicode
 
 
-class SanitizedHTML(fields.String):
+class SanitizedHTML(SanitizedUnicode):
     """String field which strips sanitizes HTML using the bleach library."""
 
     def __init__(self, tags=None, attrs=None, *args, **kwargs):

--- a/zenodo/modules/records/serializers/fields/persistentid.py
+++ b/zenodo/modules/records/serializers/fields/persistentid.py
@@ -28,10 +28,12 @@ from __future__ import absolute_import, print_function
 
 import idutils
 from flask_babelex import lazy_gettext as _
-from marshmallow import fields, missing
+from marshmallow import missing
+
+from .sanitizedunicode import SanitizedUnicode
 
 
-class PersistentId(fields.String):
+class PersistentId(SanitizedUnicode):
     """Special DOI field."""
 
     default_error_messages = {

--- a/zenodo/modules/records/serializers/fields/sanitizedurl.py
+++ b/zenodo/modules/records/serializers/fields/sanitizedurl.py
@@ -22,25 +22,20 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Custom marshmallow fields."""
+"""Sanitized Unicode string field."""
 
 from __future__ import absolute_import, print_function
 
-from .datetime import DateString
-from .doi import DOI, DOILink
-from .html import SanitizedHTML
-from .persistentid import PersistentId
-from .trimmedstring import TrimmedString
-from .sanitizedunicode import SanitizedUnicode
-from .sanitizedurl import SanitizedUrl
+from marshmallow import fields
 
-__all__ = (
-    'DateString',
-    'DOI',
-    'DOILink',
-    'PersistentId',
-    'SanitizedHTML',
-    'SanitizedUnicode',
-    'SanitizedUrl',
-    'TrimmedString',
-)
+from .sanitizedunicode import SanitizedUnicode
+
+
+class SanitizedUrl(SanitizedUnicode, fields.Url):
+    """SanitizedString-based URL field."""
+
+    def _deserialize(self, value, attr, data):
+        """Deserialize sanitized URL value."""
+        # Apply SanitizedUnicode first
+        value = SanitizedUnicode._deserialize(self, value, attr, data)
+        return fields.Url._deserialize(self, value, attr, data)

--- a/zenodo/modules/records/serializers/schemas/common.py
+++ b/zenodo/modules/records/serializers/schemas/common.py
@@ -44,7 +44,7 @@ from zenodo.modules.records.models import AccessRight
 
 from ...utils import is_deposit
 from ..fields import DOI as DOIField
-from ..fields import DateString, PersistentId, SanitizedHTML, TrimmedString
+from ..fields import DateString, PersistentId, SanitizedHTML, SanitizedUnicode
 
 
 def clean_empty(data, keys):
@@ -99,8 +99,8 @@ class RefResolverMixin(object):
 class PersonSchemaV1(Schema, StrictKeysMixin):
     """Schema for a person."""
 
-    name = TrimmedString(required=True)
-    affiliation = TrimmedString()
+    name = SanitizedUnicode(required=True)
+    affiliation = SanitizedUnicode()
     gnd = PersistentId(scheme='GND')
     orcid = PersistentId(scheme='ORCID')
 
@@ -213,7 +213,7 @@ class RelatedIdentifierSchemaV1(IdentifierSchemaV1):
 class SubjectSchemaV1(IdentifierSchemaV1):
     """Schema for a subject."""
 
-    term = TrimmedString()
+    term = SanitizedUnicode()
 
 
 class CommonMetadataSchemaV1(Schema, StrictKeysMixin, RefResolverMixin):
@@ -221,13 +221,13 @@ class CommonMetadataSchemaV1(Schema, StrictKeysMixin, RefResolverMixin):
 
     doi = DOIField()
     publication_date = DateString(required=True)
-    title = TrimmedString(required=True, validate=validate.Length(min=3))
+    title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     creators = fields.Nested(
         PersonSchemaV1, many=True, validate=validate.Length(min=1))
     description = SanitizedHTML(
         required=True, validate=validate.Length(min=3))
-    keywords = fields.List(TrimmedString())
-    notes = TrimmedString()
+    keywords = fields.List(SanitizedUnicode())
+    notes = SanitizedUnicode()
     access_right = fields.Str(validate=validate.OneOf(
         choices=[
             AccessRight.OPEN,
@@ -240,7 +240,7 @@ class CommonMetadataSchemaV1(Schema, StrictKeysMixin, RefResolverMixin):
     access_conditions = SanitizedHTML()
     subjects = fields.Nested(SubjectSchemaV1, many=True)
     contributors = fields.List(fields.Nested(ContributorSchemaV1))
-    references = fields.List(TrimmedString(attribute='raw_reference'))
+    references = fields.List(SanitizedUnicode(attribute='raw_reference'))
     related_identifiers = fields.Nested(RelatedIdentifierSchemaV1, many=True)
     alternate_identifiers = fields.Nested(
         AlternateIdentifierSchemaV1, many=True)
@@ -281,8 +281,8 @@ class CommonMetadataSchemaV1(Schema, StrictKeysMixin, RefResolverMixin):
             if value == required_doi:
                 return
 
-            err =  ValidationError(_('DOI already exists in Zenodo.'),
-                                   field_names=['doi'])
+            err = ValidationError(_('DOI already exists in Zenodo.'),
+                                  field_names=['doi'])
 
             try:
                 doi_pid = PersistentIdentifier.get('doi', value)
@@ -371,7 +371,7 @@ class CommonRecordSchemaV1(Schema, StrictKeysMixin):
     """Common record schema."""
 
     id = fields.Integer(attribute='pid.pid_value', dump_only=True)
-    doi = fields.Str(attribute='metadata.doi', dump_only=True)
+    doi = SanitizedUnicode(attribute='metadata.doi', dump_only=True)
     links = fields.Method('dump_links', dump_only=True)
     created = fields.Str(dump_only=True)
 

--- a/zenodo/modules/records/serializers/schemas/legacyjson.py
+++ b/zenodo/modules/records/serializers/schemas/legacyjson.py
@@ -35,14 +35,14 @@ from zenodo.modules.records.models import AccessRight, ObjectType
 
 from . import common
 from ...minters import doi_generator
-from ..fields import DOILink, TrimmedString
+from ..fields import DOILink, SanitizedUnicode, SanitizedUrl
 
 
 class FileSchemaV1(Schema):
     """Schema for files depositions."""
 
     id = fields.String(attribute='file_id', dump_only=True)
-    filename = fields.String(attribute='key', dump_only=True)
+    filename = SanitizedUnicode(attribute='key', dump_only=True)
     filesize = fields.Integer(attribute='size', dump_only=True)
     checksum = fields.Method('dump_checksum', dump_only=True)
     links = fields.Method('dump_links', dump_only=True)
@@ -109,28 +109,28 @@ class LegacyMetadataSchemaV1(common.CommonMetadataSchemaV1):
 
     prereserve_doi = fields.Method('dump_prereservedoi', 'load_prereservedoi')
 
-    journal_title = TrimmedString(attribute='journal.title')
-    journal_volume = TrimmedString(attribute='journal.volume')
-    journal_issue = TrimmedString(attribute='journal.issue')
-    journal_pages = TrimmedString(attribute='journal.pages')
+    journal_title = SanitizedUnicode(attribute='journal.title')
+    journal_volume = SanitizedUnicode(attribute='journal.volume')
+    journal_issue = SanitizedUnicode(attribute='journal.issue')
+    journal_pages = SanitizedUnicode(attribute='journal.pages')
 
-    conference_title = TrimmedString(attribute='meeting.title')
-    conference_acronym = TrimmedString(attribute='meeting.acronym')
-    conference_dates = TrimmedString(attribute='meeting.dates')
-    conference_place = TrimmedString(attribute='meeting.place')
-    conference_url = fields.Url(attribute='meeting.url')
-    conference_session = TrimmedString(attribute='meeting.session')
-    conference_session_part = TrimmedString(
+    conference_title = SanitizedUnicode(attribute='meeting.title')
+    conference_acronym = SanitizedUnicode(attribute='meeting.acronym')
+    conference_dates = SanitizedUnicode(attribute='meeting.dates')
+    conference_place = SanitizedUnicode(attribute='meeting.place')
+    conference_url = SanitizedUrl(attribute='meeting.url')
+    conference_session = SanitizedUnicode(attribute='meeting.session')
+    conference_session_part = SanitizedUnicode(
         attribute='meeting.session_part')
 
-    imprint_isbn = TrimmedString(attribute='imprint.isbn')
-    imprint_place = TrimmedString(attribute='imprint.place')
-    imprint_publisher = TrimmedString(attribute='imprint.publisher')
+    imprint_isbn = SanitizedUnicode(attribute='imprint.isbn')
+    imprint_place = SanitizedUnicode(attribute='imprint.place')
+    imprint_publisher = SanitizedUnicode(attribute='imprint.publisher')
 
-    partof_pages = TrimmedString(attribute='part_of.pages')
-    partof_title = TrimmedString(attribute='part_of.title')
+    partof_pages = SanitizedUnicode(attribute='part_of.pages')
+    partof_title = SanitizedUnicode(attribute='part_of.title')
 
-    thesis_university = TrimmedString(attribute='thesis.university')
+    thesis_university = SanitizedUnicode(attribute='thesis.university')
     thesis_supervisors = fields.Nested(
         common.PersonSchemaV1, many=True, attribute='thesis.supervisors')
 
@@ -355,7 +355,7 @@ class LegacyRecordSchemaV1(common.CommonRecordSchemaV1):
             '_deposit', {}).get('pid') is not None,
         dump_only=True
     )
-    title = fields.String(
+    title = SanitizedUnicode(
         attribute='metadata.title', default='', dump_only=True)
 
     def dump_state(self, o):


### PR DESCRIPTION
* Adds custom a custom marshmallow string field that washes strings
  using `ftfy` and a set of unwanted Unicode characters. (closes #917)

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>