### PR TITLE
Improve the DOI item description

### DIFF
--- a/zenodo/modules/deposit/static/json/zenodo_deposit/deposit_form.json
+++ b/zenodo/modules/deposit/static/json/zenodo_deposit/deposit_form.json
@@ -162,7 +162,7 @@
         "type": "text",
         "key": "doi",
         "title": "Digital Object Identifier",
-        "description": "Optional. Did your publisher already assign a DOI to your upload? If not, leave the field empty and we will register a new DOI for you. A DOI allows others to easily and unambiguously cite your upload.",
+        "description": "Optional. Did your publisher already assign a DOI to your upload? If not, leave the field empty and we will register a new DOI for you. A DOI allows others to easily and unambiguously cite your upload. Please note that it is NOT possible to edit a Zenodo DOI once it has been registered by us, while it is always possible to edit a custom DOI.",
         "placeholder": "e.g. 10.1234/foo.bar",
         "fa_cls": "fa-barcode"
       },


### PR DESCRIPTION
In the current upload form, the DOI description does not clearly explain the consequences of entering a custom DOI (e.g. it can be edited later) vs. leaving the DOI field empty for the Zenodo to register automatically. 

The lack of explanation raises many doubts, for example: "If I copy and paste a wrong DOI, will I be able to fix my mistake later?", "Can I upload a preprint of a paper, which will be assigned a DOI by the publisher later?," or "can I edit a DOI issued by Zenodo". Moreover, uploaders can easily overlook the fact that a Zenodo DOI cannot be changed (because they might miss the warnings elsewhere) and make "erroneous" submissions, hence get frustrated.

We (Maria de Maeztu Unit of Excellence Coordination in Universitat Pompeu Fabra, Barcelona) contacted Zenodo a couple of weeks ago for a clarification related to the issue described above. From our discussion via e-mail, we would like to suggest a improvement on the text of the DOI item description.

We believe this brief additional information will help the uploaders significantly. If you think the text is not adequate/clear, please feel free to modify it as you please. 

P.S: I took the freedom to make a pull request directly to ease the process as the change is not very big. My apologies if it would have been more appropriate to open an issue first or if I have edited a wrong document.