### PR TITLE
installation: removed redundant dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,6 @@ ftfy==4.3.1
 funcsigs==1.0.2
 future==0.16.0
 github3.py==1.0.0a4
-gnureadline==6.3.3
 html5lib==0.9999999
 humanize==0.5.1
 idna==2.1


### PR DESCRIPTION
This should fix the readthedocs builds.

Remove the stale version: http://docs.readthedocs.io/en/latest/faq.html?highlight=stale#deleting-a-stale-or-broken-build-environment