### PR TITLE
records: HTML strip from description in Dublin Core Export fix #792

### DIFF
--- a/tests/unit/records/test_schemas_dc.py
+++ b/tests/unit/records/test_schemas_dc.py
@@ -186,18 +186,20 @@ def test_sources_meetings(minimal_record, recid_pid):
     assert obj['sources'] == ['CAP, Communicating, Cape Town, March, 2010']
 
 
-def test_description(minimal_record, record_pid):
+def test_description(minimal_record, recid_pid):
     """Test description"""
     minimal_record.update({
-        'descriptions':['<p>TRPC1 and store-operated Ca2+&nbsp;(SOC) entry have \
-         previously been associated. The aim of the study was to determine genes \
-         and processes associated with&nbsp;<em>TRPC1</em>&nbsp;down-regulation \
-         and the resulting increase of SOC entry. A total of 71 genes were significantly \
-         differentially expressed (40 up- and 31 down-regulated).</p>']
-        })
+        'descriptions': ['<p>TRPC1 and store-operated Ca2+&nbsp;(SOC) entry \
+    have previously been associated. The aim of the study was to determine \
+    genes and processes associated with&nbsp;<em>TRPC1 </em>&nbsp;down- \
+    regulation and the resulting increase of SOC entry. A total of 71 \
+    genes were significantly differentially expressed (40 up- and 31 down- \
+    regulated).</p>']
+    })
     obj = dc_v1.transform_record(recid_pid, Record(minimal_record))
-    assert obj['descriptions'] == ['TRPC1 and store-operated Ca2+ (SOC) entry have \
-         previously been associated. The aim of the study was to determine genes \
-         and processes associated with TRPC1 down-regulation \
-         and the resulting increase of SOC entry. A total of 71 genes were significantly \
-         differentially expressed (40 up- and 31 down-regulated).']
+    assert obj['descriptions'] == ['TRPC1 and store-operated Ca2+ (SOC) \
+    entry have previously been associated. The aim of the study was to \
+    determine genes and processes associated with TRPC1 down-regulation and \
+    the resulting increase of SOC entry. A total of 71 genes were \
+    significantly differentially expressed (40 up- and 31 down-regulated).']
+

--- a/tests/unit/records/test_schemas_dc.py
+++ b/tests/unit/records/test_schemas_dc.py
@@ -188,7 +188,7 @@ def test_sources_meetings(minimal_record, recid_pid):
 
 def test_description(minimal_record, recid_pid):
     """Test description"""
-    minimal_record['description'] = ["<p><b>Foo&nbsp;Bar</b></p><em><p>&nbsp;\
-Foo&amp;Bar</p></em> &apos;This&apos;&nbsp;is&nbsp;<i>&lt;it&gt;<i>"]
+    minimal_record['description'] = "<p><b>Foo&nbsp;Bar</b></p><em><p>&nbsp;\
+Foo&amp;Bar</p></em> &apos;This&apos;&nbsp;is&nbsp;<i>&lt;it&gt;<i>"
     obj = dc_v1.transform_record(recid_pid, Record(minimal_record))
     assert obj['descriptions'] == ["Foo Bar Foo&Bar 'This' is <it>"]

--- a/tests/unit/records/test_schemas_dc.py
+++ b/tests/unit/records/test_schemas_dc.py
@@ -188,14 +188,12 @@ def test_sources_meetings(minimal_record, recid_pid):
 
 def test_description(minimal_record, recid_pid):
     """Test description"""
-    minimal_record.update({
-        'descriptions': ['<p>TRPC1 and store-operated Ca2+&nbsp;(SOC) entry \
+    minimal_record['descriptions'] = ['<p>TRPC1 and store-operated Ca2+&nbsp;(SOC) entry \
     have previously been associated. The aim of the study was to determine \
     genes and processes associated with&nbsp;<em>TRPC1 </em>&nbsp;down- \
     regulation and the resulting increase of SOC entry. A total of 71 \
     genes were significantly differentially expressed (40 up- and 31 down- \
     regulated).</p>']
-    })
     obj = dc_v1.transform_record(recid_pid, Record(minimal_record))
     assert obj['descriptions'] == ['TRPC1 and store-operated Ca2+ (SOC) \
     entry have previously been associated. The aim of the study was to \

--- a/tests/unit/records/test_schemas_dc.py
+++ b/tests/unit/records/test_schemas_dc.py
@@ -184,3 +184,20 @@ def test_sources_meetings(minimal_record, recid_pid):
     }
     obj = dc_v1.transform_record(recid_pid, Record(minimal_record))
     assert obj['sources'] == ['CAP, Communicating, Cape Town, March, 2010']
+
+
+def test_description(minimal_record, record_pid):
+    """Test description"""
+    minimal_record.update({
+        'descriptions':['<p>TRPC1 and store-operated Ca2+&nbsp;(SOC) entry have \
+         previously been associated. The aim of the study was to determine genes \
+         and processes associated with&nbsp;<em>TRPC1</em>&nbsp;down-regulation \
+         and the resulting increase of SOC entry. A total of 71 genes were significantly \
+         differentially expressed (40 up- and 31 down-regulated).</p>']
+        })
+    obj = dc_v1.transform_record(recid_pid, Record(minimal_record))
+    assert obj['descriptions'] == ['TRPC1 and store-operated Ca2+ (SOC) entry have \
+         previously been associated. The aim of the study was to determine genes \
+         and processes associated with TRPC1 down-regulation \
+         and the resulting increase of SOC entry. A total of 71 genes were significantly \
+         differentially expressed (40 up- and 31 down-regulated).']

--- a/zenodo/modules/records/serializers/schemas/dc.py
+++ b/zenodo/modules/records/serializers/schemas/dc.py
@@ -26,28 +26,11 @@
 
 from __future__ import absolute_import, print_function
 
+import lxml.html
+
 from marshmallow import Schema, fields
 
 from ...models import ObjectType
-
-from html.parser import HTMLParser
-
-
-class HTMLStripper(HTMLParser):
-    def __init__(self):
-        self.reset()
-        self.strict = False
-        self.convert_charrefs= True
-        self.fed = []
-    def handle_data(self, d):
-        self.fed.append(d)
-    def get_data(self):
-        return ''.join(self.fed)
-
-def strip_tags(html):
-    s = HTMLStripper()
-    s.feed(html)
-    return s.get_data()
 
 
 class DublinCoreV1(Schema):
@@ -128,7 +111,7 @@ class DublinCoreV1(Schema):
 
     def get_descriptions(self, obj):
         """Get descriptions."""
-        return [strip_tags(obj['metadata']['description'])]
+        return [lxml.html.document_fromstring(obj['metadata']['description']).text_content()]
 
     def get_subjects(self, obj):
         """Get subjects."""

--- a/zenodo/modules/records/serializers/schemas/dc.py
+++ b/zenodo/modules/records/serializers/schemas/dc.py
@@ -30,6 +30,25 @@ from marshmallow import Schema, fields
 
 from ...models import ObjectType
 
+from html.parser import HTMLParser
+
+
+class HTMLStripper(HTMLParser):
+    def __init__(self):
+        self.reset()
+        self.strict = False
+        self.convert_charrefs= True
+        self.fed = []
+    def handle_data(self, d):
+        self.fed.append(d)
+    def get_data(self):
+        return ''.join(self.fed)
+
+def strip_tags(html):
+    s = HTMLStripper()
+    s.feed(html)
+    return s.get_data()
+
 
 class DublinCoreV1(Schema):
     """Schema for records v1 in JSON."""
@@ -109,7 +128,7 @@ class DublinCoreV1(Schema):
 
     def get_descriptions(self, obj):
         """Get descriptions."""
-        return [obj['metadata']['description']]
+        return [strip_tags(obj['metadata']['description'])]
 
     def get_subjects(self, obj):
         """Get subjects."""


### PR DESCRIPTION
Strips all html tags from dc:description, so that the description is displayed without html after serailization.