### PR TITLE
deposit-ui: Added warning modal before publishing files

### DIFF
--- a/zenodo/modules/deposit/static/templates/zenodo_deposit/actions.html
+++ b/zenodo/modules/deposit/static/templates/zenodo_deposit/actions.html
@@ -32,6 +32,18 @@
     <li>
       <button
         class="btn btn-primary"
+        data-toggle="modal"
+        data-target="#warningModal"
+        ng-hide="recordsVM.invenioRecordsArgs.templateParams.is_published"
+        ng-disabled="depositionForm.$invalid || depositionForm.$dirty || recordsVM.invenioRecordsLoading"
+        ng-attr-title="{{(depositionForm.$invalid || depositionForm.$dirty || recordsVM.invenioRecordsLoading) && 'You need to save your deposit first' || 'Publish the record'}}">
+        <i class="fa fa-check"></i> Publish
+      </button>
+    </li>
+    <li>
+      <button
+        class="btn btn-primary"
+        ng-hide="!recordsVM.invenioRecordsArgs.templateParams.is_published"
         ng-disabled="depositionForm.$invalid || depositionForm.$dirty || recordsVM.invenioRecordsLoading"
         ng-attr-title="{{(depositionForm.$invalid || depositionForm.$dirty || recordsVM.invenioRecordsLoading) && 'You need to save your deposit first' || 'Publish the record'}}"
         ng-click="recordsVM.actionHandler(['publish', 'POST'], 'record_html')">
@@ -39,4 +51,28 @@
       </button>
     </li>
   </ul>
+</div>
+
+<div class="modal fade" id="warningModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button class="close" data-dismiss="modal"><span>&times;</span></button>
+        <h4 class="modal-title">Warning</h4>
+      </div>
+      <div class="modal-body">
+        File addition, removal or modification are not allowed after you have published your upload. This is because a Digital Object Identifier (DOI) is registered with DataCite for each upload.
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button
+          class="btn btn-primary"
+          ng-disabled="depositionForm.$invalid || depositionForm.$dirty || recordsVM.invenioRecordsLoading"
+          ng-attr-title="{{(depositionForm.$invalid || depositionForm.$dirty || recordsVM.invenioRecordsLoading) && 'You need to save your deposit first' || 'Publish the record'}}"
+          ng-click="recordsVM.actionHandler(['publish', 'POST'], 'record_html')">
+          <i class="fa fa-check"></i> I understand
+        </button>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Enhancement Fix for deposit-ui: show a warning before publishing that
files cannot be replaced Issue #848.

Changes:
1. Added new "Publish" button that opens up a warning modal if deposit has not been published
2. Changed current "Publish" button to show only when deposit has already been published
3. Added "Warning" modal with "I understand" button to warn users that files cannot be modified once published