### PR TITLE
global: change localhost to ZENODO_DOCKER_HOST in default configuration.

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -22,6 +22,16 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+if [[ `uname` == 'Darwin' ]]; then
+    # When developing with docker on MacOS (or Windows), all the ports are exposed to a VM
+    # instead of localhost
+    # For example, we may have
+    #   DOCKER_HOST="tcp://192.168.99.100:2376"  (avaiable by running docker-machine env)
+    # then
+    #   ZENODO_DOCKER_HOST = "192.168.99.100"
+    export ZENODO_DOCKER_HOST=$(docker-machine env | awk -F '://' '/DOCKER_HOST=/ {print $2}' | awk -F ':' '{print $1}')
+    echo 'export ZENODO_DOCKER_HOST='$ZENODO_DOCKER_HOST
+fi
 zenodo db create
 zenodo index queue init
 zenodo index init

--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -71,6 +71,8 @@ def _(x):
     """Identity function for string extraction."""
     return x
 
+# : Default docker host address
+ZENODO_DOCKER_HOST = os.environ.get("ZENODO_DOCKER_HOST", "localhost")
 #: Email address for support.
 SUPPORT_EMAIL = "info@zenodo.org"
 MAIL_SUPPRESS_SEND = True
@@ -120,9 +122,9 @@ I18N_LANGUAGES = []
 # Celery
 # ======
 #: Default broker (RabbitMQ on locahost).
-BROKER_URL = "amqp://guest:guest@localhost:5672//"
+BROKER_URL = "amqp://guest:guest@{}:5672//".format(ZENODO_DOCKER_HOST)
 #: Default Celery result backend.
-CELERY_RESULT_BACKEND = "redis://localhost:6379/1"
+CELERY_RESULT_BACKEND = "redis://{}:6379/1".format(ZENODO_DOCKER_HOST)
 #: Accepted content types for Celery.
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 #: Beat schedule
@@ -146,7 +148,7 @@ CELERYBEAT_SCHEDULE = {
 #: Cache key prefix
 CACHE_KEY_PREFIX = "cache::"
 #: Host
-CACHE_REDIS_HOST = "localhost"
+CACHE_REDIS_HOST = "{}".format(ZENODO_DOCKER_HOST)
 #: Port
 CACHE_REDIS_PORT = 6379
 #: DB
@@ -157,7 +159,7 @@ CACHE_REDIS_URL = "redis://{0}:{1}/{2}".format(
 #: Default cache type.
 CACHE_TYPE = "redis"
 #: Default cache URL for sessions.
-ACCOUNTS_SESSION_REDIS_URL = "redis://localhost:6379/2"
+ACCOUNTS_SESSION_REDIS_URL = "redis://{}:6379/2".format(ZENODO_DOCKER_HOST)
 #: Cache for storing access restrictions
 ACCESS_CACHE = 'zenodo.modules.cache:current_cache'
 
@@ -840,6 +842,10 @@ SECURITY_DEPRECATED_PASSWORD_SCHEMES = [
 
 # Search
 # ======
+#: Default ElasticSearch host
+SEARCH_ELASTIC_HOSTS = [
+    {"host": ZENODO_DOCKER_HOST}
+]
 #: Default API endpoint for search UI.
 SEARCH_UI_SEARCH_API = "/api/records/"
 #: Accept header fro search-js
@@ -913,9 +919,9 @@ USERPROFILES_EXTEND_SECURITY_FORMS = True
 # Database
 # ========
 #: Default database host.
-SQLALCHEMY_DATABASE_URI = os.environ.get(
+SQALCHEMY_DATABASE_URI = os.environ.get(
     "SQLALCHEMY_DATABASE_URI",
-    "postgresql+psycopg2://zenodo:zenodo@localhost/zenodo")
+    "postgresql+psycopg2://zenodo:zenodo@{}/zenodo").format(ZENODO_DOCKER_HOST)
 #: Do not print SQL queries to console.
 SQLALCHEMY_ECHO = False
 #: Track modifications to objects.


### PR DESCRIPTION
The purpose is to make it easier to setup development environment on non-linux systems (e.g., MacOS and Windows).
In these systems, docker runs inside a VM, and the host address is different from localhost.