### PR TITLE
Use ; instead of , to separate authors

### DIFF
--- a/zenodo/modules/records/serializers/json.py
+++ b/zenodo/modules/records/serializers/json.py
@@ -41,6 +41,28 @@ class ZenodoJSONSerializer(JSONSerializer):
     context to the request serializer.
     """
 
+    @staticmethod
+    def _format_args():
+        """Get JSON dump indentation and separates."""
+        # Ensure we can run outside a application/request context.
+        try:
+            pretty_format = \
+                current_app.config['JSONIFY_PRETTYPRINT_REGULAR'] and \
+                not request.is_xhr
+        except RuntimeError:
+            pretty_format = False
+
+        if pretty_format:
+            return dict(
+                indent=2,
+                separators=('; ', ': '),
+            )
+        else:
+            return dict(
+                indent=None,
+                separators=(';', ':'),
+            )
+
     def preprocess_record(self, pid, record, links_factory=None):
         """Include files for single record retrievals."""
         result = super(ZenodoJSONSerializer, self).preprocess_record(


### PR DESCRIPTION
The authors below the *Cite as* heading should be separated by a semicolon instead of a comma as the  authors right below the name of the publication are. The current display makes it hard to distinguish between first name, last name and the next author in the list.

![zenodo-separator-bug](https://cloud.githubusercontent.com/assets/2678428/24601075/d15ee668-1857-11e7-979e-f9953e45083a.png)

I dug through the code and believe that Zenodo's class [`ZenodoJSONSerializer`](https://github.com/zenodo/zenodo/blob/master/zenodo/modules/re/zenodo/modules/records/serializers/json.pycords/serializers/json.py#L37) should redefine its parent class' function [`_format_args()`](https://github.com/inveniosoftware/invenio-records-rest/blob/master/invenio_records_rest/serializers/json.py#L42) to return a dictionary with `;` instead of `,` as separator.

This pull request fixes the issue.