### PR TITLE
directly opening url - /deposit/:id will open the deposit in edit mode

### DIFF
--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -433,6 +433,7 @@ DEPOSIT_RECORDS_UI_ENDPOINTS = {
         'route': '/deposit/<pid_value>',
         'template': 'zenodo_deposit/edit.html',
         'record_class': 'zenodo.modules.deposit.api:ZenodoDeposit',
+        'view_imp': 'zenodo.modules.deposit.views.default_view_method',
     },
 }
 


### PR DESCRIPTION
@lnielsen Sir
I have added the code - 
ADDRESSING enhacement #764 
Now when directly /deposit/:id url request is made, it will make deposit editable even if it was not in edit mode by changing the deposit status to draft.