### PR TITLE
docker: remove read_only from rabbitmq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,6 @@ mq:
   ports:
     - "15672:15672"
     - "5672:5672"
-  read_only: true
 es:
   build: ./docker/es/
   restart: "always"


### PR DESCRIPTION
* Fixes issue with container creation for newer versions of the
  rabbitmq docker image.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>