### PR TITLE
records: citation fixes

### DIFF
--- a/tests/unit/records/test_schemas_csl.py
+++ b/tests/unit/records/test_schemas_csl.py
@@ -39,7 +39,7 @@ def test_minimal(app, minimal_record, recid_pid):
     d = datetime.utcnow().date()
     assert obj == {
         'id': '123',
-        'type': 'dataset',
+        'type': 'article',
         'title': 'Test',
         'abstract': 'My description',
         'author': [

--- a/zenodo/modules/records/data/objecttypes.json
+++ b/zenodo/modules/records/data/objecttypes.json
@@ -123,7 +123,7 @@
   "datacite": {"general": "Software"},
   "eurepo": "info:eu-repo/semantics/other",
   "schema.org": "http://schema.org/Code",
-  "csl": "dataset"
+  "csl": "article"
 },
 {
   "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
@@ -250,7 +250,7 @@
   "datacite": {"general": "Text", "type": "Report"},
   "eurepo": "info:eu-repo/semantics/report",
   "parent": {"$ref": "http://zenodo.org/objecttypes/publication"},
-  "csl": "report"
+  "csl": "article"
 },
 {
   "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",


### PR DESCRIPTION
* Fixes issue with software having "[dataset]" in the default ciation.
  Based on discussion with CSL developers, the best is to use article
  for software instead of dataset as then the type is not included in
  the citation.

* Fixes issue with reports not having a DOI in the default APA citation.
  (closes #1074)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>