### PR TITLE
config: MathJax CDN update

### DIFF
--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -944,9 +944,10 @@ THEME_GOOGLE_SITE_VERIFICATION = [
 #: Piwik site id.
 THEME_PIWIK_ID = None
 
-THEME_MATHJAX_CDN = \
-    '//cdn.mathjax.org/mathjax/latest/MathJax.js' \
+THEME_MATHJAX_CDN = (
+    '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js'
     '?config=TeX-AMS-MML_HTMLorMML'
+)
 
 #: Base template for entire site.
 BASE_TEMPLATE = "zenodo_theme/page.html"


### PR DESCRIPTION
* Changes the MathJax CDN to use cdnjs.cloudflare.com. (closes #1053)

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>