### PR TITLE
versioning: GitHub non-versioned releases upgrades

### DIFF
--- a/tests/unit/communities/test_communities_api.py
+++ b/tests/unit/communities/test_communities_api.py
@@ -21,6 +21,8 @@
 
 from __future__ import absolute_import, print_function
 
+from six import BytesIO, b
+
 from helpers import publish_and_expunge
 from invenio_communities.models import InclusionRequest
 from invenio_pidrelations.contrib.versioning import PIDVersioning
@@ -43,6 +45,7 @@ def test_basic_api(app, db, communities, deposit, deposit_file):
     pv = PIDVersioning(child=recid_v1)
     depid_v2 = pv.draft_child_deposit
     deposit_v2 = ZenodoDeposit.get_record(depid_v2.get_assigned_object())
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     deposit_v2 = publish_and_expunge(db, deposit_v2)
     deposit_v2 = deposit_v2.edit()
     # 1. Request for 'c1' and 'c2' through deposit v2
@@ -101,6 +104,7 @@ def test_autoadd(app, db, users, communities, deposit, deposit_file,
     depid_v2 = pv.draft_child_deposit
     depid_v2_value = depid_v2.pid_value
     deposit_v2 = ZenodoDeposit.get_record(depid_v2.get_assigned_object())
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     deposit_v2 = publish_and_expunge(db, deposit_v2)
     deposit_v2 = deposit_v2.edit()
     # 1. Request for 'c1' and 'c3' (owned by user) through deposit v2
@@ -210,6 +214,7 @@ def test_autoadd_explicit_newversion(
 
     deposit_v2['communities'] = ['ecfunded', 'grants_comm', 'zenodo']
     deposit_v2['grants'] = [{'title': 'SomeGrant'}, ]
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     deposit_v2 = publish_and_expunge(db, deposit_v2)
     recid_v2, record_v2 = deposit_v2.fetch_published()
 
@@ -249,6 +254,7 @@ def test_communities_newversion_addition(
     # Remove 'c2' and request for 'c5'. Make sure that communities from
     # previous record version are preserved/removed properly
     deposit_v2['communities'] = ['c1', 'c5']
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     deposit_v2 = publish_and_expunge(db, deposit_v2)
     recid_v2, record_v2 = deposit_v2.fetch_published()
 
@@ -284,6 +290,7 @@ def test_communities_newversion_while_ir_pending_bug(
 
     deposit_v2 = ZenodoDeposit.get_record(depid_v2.get_assigned_object())
 
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     deposit_v2 = publish_and_expunge(db, deposit_v2)
     recid_v2, record_v2 = deposit_v2.fetch_published()
 
@@ -328,6 +335,7 @@ def test_propagation_with_newversion_open(
 
     depid_v2, deposit_v2 = deposit_resolver.resolve(depid_v2_value)
     assert deposit_v2['communities'] == ['c1', 'c2']
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     deposit_v2 = publish_and_expunge(db, deposit_v2)
     recid_v2, record_v2 = deposit_v2.fetch_published()
 

--- a/tests/unit/deposit/test_deposit_index.py
+++ b/tests/unit/deposit/test_deposit_index.py
@@ -24,6 +24,8 @@
 
 from __future__ import absolute_import, print_function
 
+from six import BytesIO, b
+
 from helpers import publish_and_expunge
 from invenio_deposit.api import Deposit
 from invenio_indexer.api import RecordIndexer
@@ -117,6 +119,7 @@ def test_versioning_indexing(db, es, deposit, deposit_file):
     pv = PIDVersioning(child=recid_v1)
     depid_v2 = pv.draft_child_deposit
     deposit_v2 = ZenodoDeposit.get_record(depid_v2.object_uuid)
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     depid_v1, deposit_v1 = deposit_resolver.resolve(depid_v1_value)
 
     RecordIndexer().process_bulk_queue()

--- a/tests/unit/records/test_records_relations_serialization.py
+++ b/tests/unit/records/test_records_relations_serialization.py
@@ -21,6 +21,8 @@
 
 from __future__ import absolute_import, print_function
 
+from six import BytesIO, b
+
 from helpers import publish_and_expunge
 from invenio_pidrelations.contrib.versioning import PIDVersioning
 from invenio_pidrelations.serializers.utils import serialize_relations
@@ -88,6 +90,7 @@ def test_relations_serialization(app, db, deposit, deposit_file):
     pv = PIDVersioning(child=recid_v1)
     depid_v2 = pv.draft_child_deposit
     deposit_v2 = ZenodoDeposit.get_record(depid_v2.get_assigned_object())
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     deposit_v2 = publish_and_expunge(db, deposit_v2)
     recid_v2, record_v2 = deposit_v2.fetch_published()
     depid_v1, deposit_v1 = deposit_resolver.resolve(depid_v1_value)
@@ -148,6 +151,7 @@ def test_related_identifiers_serialization(app, db, deposit, deposit_file):
     pv = PIDVersioning(child=recid_v1)
     depid_v2 = pv.draft_child_deposit
     deposit_v2 = ZenodoDeposit.get_record(depid_v2.get_assigned_object())
+    deposit_v2.files['file.txt'] = BytesIO(b('file1'))
     deposit_v2 = publish_and_expunge(db, deposit_v2)
     deposit_v2 = deposit_v2.edit()
     # 1. Request for 'c1' and 'c2' through deposit v2

--- a/zenodo/modules/deposit/errors.py
+++ b/zenodo/modules/deposit/errors.py
@@ -40,6 +40,16 @@ class MissingFilesError(RESTValidationError):
     ]
 
 
+class VersioningFilesError(RESTValidationError):
+    """Error when new version's files exist in one of the old versions."""
+
+    errors = [
+        FieldError(None, _(
+            "New version's files must differ from all previous versions."),
+            code=10)
+    ]
+
+
 class OngoingMultipartUploadError(RESTValidationError):
     """Error for when no files have been provided."""
 

--- a/zenodo/modules/deposit/views.py
+++ b/zenodo/modules/deposit/views.py
@@ -211,13 +211,18 @@ def delete(pid=None, record=None, depid=None, deposit=None):
     except PIDDoesNotExistError:
         doi = None
 
-    try:
-        if 'conceptdoi' in record:
-            conceptdoi = PersistentIdentifier.get('doi', record['conceptdoi'])
-            conceptrecid = PersistentIdentifier.get('recid',
-                                                    record['conceptrecid'])
-    except PIDDoesNotExistError:
+    pids = [pid, depid, doi]
+    if 'conceptdoi' in record:
+        conceptdoi = PersistentIdentifier.get('doi', record['conceptdoi'])
+        pids.append(conceptdoi)
+    else:
         conceptdoi = None
+
+    if 'conceptrecid' in record:
+        conceptrecid = PersistentIdentifier.get('recid',
+                                                record['conceptrecid'])
+        pids.append(conceptrecid)
+    else:
         conceptrecid = None
 
     form = RecordDeleteForm()
@@ -272,8 +277,6 @@ def delete(pid=None, record=None, depid=None, deposit=None):
             category='success'
         )
         return redirect(url_for('zenodo_frontpage.index'))
-
-    pids = [p for p in (pid, depid, doi, conceptrecid, conceptdoi) if p]
     return render_template(
         'zenodo_deposit/delete.html',
         form=form,

--- a/zenodo/modules/github/api.py
+++ b/zenodo/modules/github/api.py
@@ -39,8 +39,8 @@ from invenio_pidrelations.contrib.versioning import PIDVersioning
 from invenio_pidstore.models import PersistentIdentifier
 from werkzeug.utils import cached_property
 
-from zenodo.modules.deposit.tasks import datacite_register
 from zenodo.modules.deposit.api import ZenodoDeposit
+from zenodo.modules.deposit.tasks import datacite_register
 from zenodo.modules.records.api import ZenodoRecord
 
 from ..deposit.loaders import legacyjson_v1_translator


### PR DESCRIPTION
* Automatically upgrades a non-versioned GitHub records to versioning
  on new releases.

* Fixes a bug with record versioning upgrade.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>