### PR TITLE
installation: added skipping of deploy tags builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ cache:
     - $HOME/.cache/pip
     - $HOME/.nvm
 
+branches:
+  except:
+    - /^deploy-.*$/
+
 services:
   - postgresql
   - redis


### PR DESCRIPTION
* Skips the builds for branches (tags) which starting with 'deploy-'.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>