### PR TITLE
oaiserver: fix date granularity harvesting

### DIFF
--- a/requirements.pinned.txt
+++ b/requirements.pinned.txt
@@ -21,3 +21,6 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+# 2.13.5 break Invenio-OAIServer date granularity validation.
+marshmallow==2.13.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,7 +161,6 @@ limits==1.2.0
 lxml==3.6.4
 Mako==1.0.6
 MarkupSafe==0.23
-marshmallow==2.13.5
 mistune==0.7.3
 mock==2.0.0
 msgpack-python==0.4.8

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ install_requires = [
     'invenio-webhooks>=1.0.0a4',
     'jsonref>=0.1',
     'jsonresolver>=0.2.1',
-    'marshmallow>=2.13.5',
+    'marshmallow==2.13.4',
     'Pillow>=3.4.2',
     'python-slugify>=1.2.1',
     'raven<=5.1.0',


### PR DESCRIPTION
* Fixes issue which prevents date granularity harvesting. Root cause
  was breaking change in datetime validation introduced between
  marshamllow 2.13.4 and 2.13.5.