### PR TITLE
serializers: identifier order fix for oai_dc

### DIFF
--- a/tests/unit/records/test_schemas_dc.py
+++ b/tests/unit/records/test_schemas_dc.py
@@ -37,7 +37,7 @@ def test_minimal(app, db, minimal_record_model, recid_pid):
     assert obj == {
         'sources': [],
         'contributors': [],
-        'identifiers': ['', 'https://zenodo.org/record/123'],
+        'identifiers': ['https://zenodo.org/record/123', ''],
         'subjects': [],
         'languages': [''],
         'dates': [datetime.utcnow().date().isoformat()],
@@ -56,7 +56,7 @@ def test_identifiers(app, db, minimal_record_model, recid_pid):
     minimal_record_model['doi'] = '10.1234/foo'
     obj = dc_v1.transform_record(recid_pid, minimal_record_model)
     assert obj['identifiers'] == \
-        ['10.1234/foo', 'https://zenodo.org/record/123']
+        ['https://zenodo.org/record/123', '10.1234/foo']
 
     minimal_record_model['_oai'] = {'id': 'oai:zenodo.org:123'}
     obj = dc_v1.transform_record(recid_pid, minimal_record_model)

--- a/zenodo/modules/records/serializers/schemas/dc.py
+++ b/zenodo/modules/records/serializers/schemas/dc.py
@@ -50,9 +50,10 @@ class DublinCoreV1(Schema):
 
     def get_identifiers(self, obj):
         """Get identifiers."""
-        items = [obj['metadata'].get('doi', u'')]
+        items = []
         items.append(u'https://zenodo.org/record/{0}'.format(
             obj['metadata']['recid']))
+        items.append(obj['metadata'].get('doi', u''))
         oai = obj['metadata'].get('_oai', {}).get('id')
         if oai:
             items.append(oai)


### PR DESCRIPTION
* Reorders serialized identifiers to display the Zenodo URL first.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>