### PR TITLE
metadata-extractor: extractor metadata modal

### DIFF
--- a/zenodo/modules/deposit/static/templates/zenodo_deposit/list.html
+++ b/zenodo/modules/deposit/static/templates/zenodo_deposit/list.html
@@ -80,15 +80,34 @@
           <div class="modal-dialog">
             <div class="modal-content">
               <div class="modal-header">
-                <h1 class="modal-title">Metadata</h1>
+                <h1 class="modal-title">Extracted metadata</h1>
+                <small class="text-muted">
+                Apply any of the extracted metadata by clicking the corresponding "Apply extracted" button. The value will overwrite the current value on the form.
+                </small>
               </div>
-              <div class="modal-body">
-                <pre> {{ recordMetadata | json }} </pre>
+              <div class="modal-body" style="overflow-y:auto; height:600px">
+                <div ng-hide="recordMetadata.ready">
+                  <center><strong>Extracting...</strong></center>
+                </div>
+                <div ng-show="recordMetadata.ready">
+                  <div ng-repeat="item in recordMetadata.metafields">
+                    <i class="fa {{item.fa_cls}}"></i> <strong>{{ item.title }}</strong>
+                    <button type="button" class="btn btn-xs btn-success" ng-model="recordMetadata" ng-click="applyMetadata(item)" aria-label="Apply extracted" ng-disabled="item.applied" apply-button>Apply extracted</button>
+                    <ul class="list-group">
+                      <li class="list-group-item list-group-item-warning">
+                        <strong>Current:</strong><br />
+                        {{ recordsVM.invenioRecordsModel[item.key]}}
+                      </li>
+                      <li class="list-group-item list-group-item-success">
+                        <strong>Extracted:</strong><br /> {{ item.data }}
+                      </li>
+                    </ul>
+                  </div>
+                </div>
               </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-default" ng-click="$hide()" aria-label="Close" data-dismiss="modal">Close</button>
                 <!--NOTES: I try to use ng-disabled="!recordMetada.ready" here. But it does work as what I expected. -->
-                <button type="button" class="btn btn-success" ng-model="recordMetadata" ng-click="applyMetadata();$hide()" data-dismiss="modal" aria-label="Apply" apply-button>Apply</button>
               </div>
             </div>
           </div>

--- a/zenodo/modules/deposit/static/templates/zenodo_deposit/list.html
+++ b/zenodo/modules/deposit/static/templates/zenodo_deposit/list.html
@@ -65,13 +65,37 @@
         <span ng-show="f.completed" class="text-success"><i class="fa fa-check"></i></span>
       </td>
       <td class="text-center">
+        <div ng-controller="metadataCtl">
         <button
           ng-show="f.completed"
           class="btn btn-xs btn-default form-button {{ form.fieldHtmlClass }}"
           ng-click="extractMetadata(f)"
+          data-toggle="modal"
+          data-target="#metadataModel"
           extract-button
         >
+       <!--"-->
         <i ng-show="f.completed" class="fa fa-magic" aria-hidden="true"></a></td>
+        <div class="modal center" id="metadataModel" tabindex="-1" role="dialog" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h1 class="modal-title">Metadata</h1>
+              </div>
+              <div class="modal-body">
+                <pre> {{ recordMetadata | json }} </pre>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" ng-click="$hide()" aria-label="Close" data-dismiss="modal">Close</button>
+                <!--NOTES: I try to use ng-disabled="!recordMetada.ready" here. But it does work as what I expected. -->
+                <button type="button" class="btn btn-success" ng-model="recordMetadata" ng-click="applyMetadata();$hide()" data-dismiss="modal" aria-label="Apply" apply-button>Apply</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        </div>
+
       </td>
       <td ng-show="f" class="text-center"><a href="#" ng-click="filesVM.remove(f)"><i class="fa fa-trash-o"></a></td>
     </tr>

--- a/zenodo/modules/deposit/templates/zenodo_deposit/edit.html
+++ b/zenodo/modules/deposit/templates/zenodo_deposit/edit.html
@@ -154,6 +154,7 @@
               var url = `/filesprocessor/${ processor_name }/${ f.version_id }`
               $rootScope.$broadcast('invenio.records.loading.start');
 
+              $scope.recordMetadata.ready = false
               InvenioRecordsAPI.request({
                 method: 'POST',
                 url: url,
@@ -161,13 +162,37 @@
                 headers: {}
               }).then(function success(resp) {
                 console.log(resp.data)
-                $scope.recordMetadata.title = resp.data.title
-                $scope.recordMetadata.description= resp.data.description
-                $scope.recordMetadata.creators = resp.data.creators
-                $scope.recordMetadata.keywords = resp.data.keywords
                 $scope.recordMetadata.ready = true
-                $rootScope.$broadcast(
-                  'invenio.records.endpoints.updated', resp.data);
+                $scope.recordMetadata.metafields = [
+                  {
+                    "title": "Title",
+                    "fa_cls": "fa-book",
+                    "key": "title",
+                    "applied": false,
+                    "data": resp.data.title
+                  },
+                  {
+                    "title": "Description",
+                    "fa_cls": "fa-pencil",
+                    "key": "description",
+                    "applied": false,
+                    "data": resp.data.description
+                  },
+                  {
+                    "title": "Creators",
+                    "fa_cls": "fa-user",
+                    "key": "creators",
+                    "applied": false,
+                    "data": resp.data.creators
+                  },
+                  {
+                    "title": "Keywords",
+                    "fa_cls": "fa-tags",
+                    "key": "keywords",
+                    "applied": false,
+                    "data": resp.data.keywords
+                  }
+                ]
               }, function error(resp) {
                 $rootScope.$broadcast('invenio.records.alert', {
                   type: 'danger',
@@ -192,11 +217,9 @@
         .directive('applyButton',['$rootScope', 'InvenioRecordsAPI', function($rootScope, InvenioRecordsAPI) {
 
           function link($scope, elem, attrs, vm) {
-            $scope.applyMetadata = function(f) {
-              vm.invenioRecordsModel.title = $scope.recordMetadata.title
-              vm.invenioRecordsModel.description= $scope.recordMetadata.description
-              vm.invenioRecordsModel.creators = $scope.recordMetadata.creators
-              vm.invenioRecordsModel.keywords = $scope.recordMetadata.keywords
+            $scope.applyMetadata = function(item) {
+              vm.invenioRecordsModel[item.key] = item.data
+              item.applied=true
             };
           }
           return {

--- a/zenodo/modules/deposit/templates/zenodo_deposit/edit.html
+++ b/zenodo/modules/deposit/templates/zenodo_deposit/edit.html
@@ -136,6 +136,13 @@
         }]);
 
         angular.module('invenioRecords.directives')
+        .controller('metadataCtl', function($rootScope) {
+          $rootScope.recordMetadata = {
+            ready: false
+          };
+        });
+
+        angular.module('invenioRecords.directives')
         .directive('extractButton',['$rootScope', 'InvenioRecordsAPI', function($rootScope, InvenioRecordsAPI) {
 
           function link($scope, elem, attrs, vm) {
@@ -147,7 +154,6 @@
               var url = `/filesprocessor/${ processor_name }/${ f.version_id }`
               $rootScope.$broadcast('invenio.records.loading.start');
 
-              // Question: what is the correct way to get the (binary) content of a file?
               InvenioRecordsAPI.request({
                 method: 'POST',
                 url: url,
@@ -155,10 +161,11 @@
                 headers: {}
               }).then(function success(resp) {
                 console.log(resp.data)
-                vm.invenioRecordsModel.title = resp.data.title
-                vm.invenioRecordsModel.description= resp.data.description
-                vm.invenioRecordsModel.creators = resp.data.creators
-                vm.invenioRecordsModel.keywords = resp.data.keywords
+                $scope.recordMetadata.title = resp.data.title
+                $scope.recordMetadata.description= resp.data.description
+                $scope.recordMetadata.creators = resp.data.creators
+                $scope.recordMetadata.keywords = resp.data.keywords
+                $scope.recordMetadata.ready = true
                 $rootScope.$broadcast(
                   'invenio.records.endpoints.updated', resp.data);
               }, function error(resp) {
@@ -173,6 +180,25 @@
             };
           }
 
+          return {
+            scope: false,
+            restrict: 'A',
+            require: '^invenioRecords',
+            link: link,
+          };
+        }]);
+
+        angular.module('invenioRecords.directives')
+        .directive('applyButton',['$rootScope', 'InvenioRecordsAPI', function($rootScope, InvenioRecordsAPI) {
+
+          function link($scope, elem, attrs, vm) {
+            $scope.applyMetadata = function(f) {
+              vm.invenioRecordsModel.title = $scope.recordMetadata.title
+              vm.invenioRecordsModel.description= $scope.recordMetadata.description
+              vm.invenioRecordsModel.creators = $scope.recordMetadata.creators
+              vm.invenioRecordsModel.keywords = $scope.recordMetadata.keywords
+            };
+          }
           return {
             scope: false,
             restrict: 'A',


### PR DESCRIPTION
There are some unresolved UI problems.

1. Disable the apply button before the extraction is completed. `ng-disabled` does not work as I expected.
2. Close the modal when I apply the changes.  I use `ng-click="applyMetadata();$hide()" ` in the code. But it seems `$hide()` is not executed.