### PR TITLE
deposit-ui: hide a field if the extracted data is null and allow add …

### DIFF
--- a/zenodo/modules/deposit/static/templates/zenodo_deposit/list.html
+++ b/zenodo/modules/deposit/static/templates/zenodo_deposit/list.html
@@ -74,7 +74,6 @@
           data-target="#metadataModel"
           extract-button
         >
-       <!--"-->
         <i ng-show="f.completed" class="fa fa-magic" aria-hidden="true"></a></td>
         <div class="modal center" id="metadataModel" tabindex="-1" role="dialog" aria-hidden="true">
           <div class="modal-dialog">
@@ -90,24 +89,31 @@
                   <center><strong>Extracting...</strong></center>
                 </div>
                 <div ng-show="recordMetadata.ready">
-                  <div ng-repeat="item in recordMetadata.metafields">
+                  <div ng-repeat="item in recordMetadata.metafields" ng-show="item.data != null">
                     <i class="fa {{item.fa_cls}}"></i> <strong>{{ item.title }}</strong>
                     <button type="button" class="btn btn-xs btn-success" ng-model="recordMetadata" ng-click="applyMetadata(item)" aria-label="Apply extracted" ng-disabled="item.applied" apply-button>Apply extracted</button>
                     <ul class="list-group">
                       <li class="list-group-item list-group-item-warning">
                         <strong>Current:</strong><br />
-                        {{ recordsVM.invenioRecordsModel[item.key]}}
+                        {{ recordsVM.invenioRecordsModel[item.key] }}
                       </li>
                       <li class="list-group-item list-group-item-success">
-                        <strong>Extracted:</strong><br /> {{ item.data }}
-                      </li>
-                    </ul>
+                        <strong>Extracted:</strong><br/>
+                        <div ng-if="!item.sequence">
+                          {{ item.data }}
+                        </div>
+                        <div ng-if="item.sequence">
+                            <div ng-repeat="entry in item.data">
+                              {{ entry }}
+                              <button type="button" class="btn btn-xs btn-success"
+                              ng-model="recordMetadata" ng-click="appendMetadata(item.key, entry)" aria-label="Add" apply-button>Add</button>
+                            </div>
+                        </div>
                   </div>
                 </div>
               </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-default" ng-click="$hide()" aria-label="Close" data-dismiss="modal">Close</button>
-                <!--NOTES: I try to use ng-disabled="!recordMetada.ready" here. But it does work as what I expected. -->
               </div>
             </div>
           </div>

--- a/zenodo/modules/deposit/templates/zenodo_deposit/edit.html
+++ b/zenodo/modules/deposit/templates/zenodo_deposit/edit.html
@@ -168,6 +168,7 @@
                     "title": "Title",
                     "fa_cls": "fa-book",
                     "key": "title",
+                    "sequence": false,
                     "applied": false,
                     "data": resp.data.title
                   },
@@ -176,12 +177,14 @@
                     "fa_cls": "fa-pencil",
                     "key": "description",
                     "applied": false,
+                    "sequence": false,
                     "data": resp.data.description
                   },
                   {
                     "title": "Creators",
                     "fa_cls": "fa-user",
                     "key": "creators",
+                    "sequence": true,
                     "applied": false,
                     "data": resp.data.creators
                   },
@@ -189,6 +192,7 @@
                     "title": "Keywords",
                     "fa_cls": "fa-tags",
                     "key": "keywords",
+                    "sequence": true,
                     "applied": false,
                     "data": resp.data.keywords
                   }
@@ -220,6 +224,15 @@
             $scope.applyMetadata = function(item) {
               vm.invenioRecordsModel[item.key] = item.data
               item.applied=true
+            };
+
+            $scope.appendMetadata = function(key, entry) {
+              if(vm.invenioRecordsModel[key][0] &&
+              Object.keys(vm.invenioRecordsModel[key][0]).length){
+                vm.invenioRecordsModel[key].push(entry)
+              }else{
+                vm.invenioRecordsModel[key]=[entry]
+              }
             };
           }
           return {


### PR DESCRIPTION
…a single creator/keyword

Signed-off-by: Xiao Meng <xiaom.cs@gmail.com>

It should also resolve https://github.com/zenodo/zenodo/issues/1238

The UI still needs some polish.

First, the field "creators" and "keywords" are ordered array.  But we do not forbid users to add them in an arbitrary order.

Second, we want to disable the button "add" after users clicked it. To track whether an entry is already added, we may use a dictionary to track the state. Not sure whether this is a good solution.
