### PR TITLE
deposit-ui: fix IE 11 compatibility

### DIFF
--- a/zenodo/modules/deposit/static/templates/zenodo_deposit/select.html
+++ b/zenodo/modules/deposit/static/templates/zenodo_deposit/select.html
@@ -14,7 +14,6 @@
             schema-validate="form"
             ng-options="item.value as item.name group by item.group for item in form.titleMap"
             name="{{ form.key.slice(-1)[0] }}">
-      <option ng-if="form.placeholder" disabled selected value="">{{ form.placeholder }}</option>
     </select>
     <div class="help-block" sf-message="form.description"></div>
   </div>


### PR DESCRIPTION
* Removes blank placeholder for select form fields, because of bad
  behaviour in IE 11. (closes #1319)

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>