### PR TITLE
Secure & update hyperlinks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ any size, any format and from any science.
 Powered by Invenio
 ------------------
 Zenodo is a small layer on top of
-`Invenio <http://github.com/inveniosoftware/invenio>`_, a ​free software
+`Invenio <https://github.com/inveniosoftware/invenio>`_, a ​free software
 suite enabling you to run your own ​digital library or document repository on
 the web.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,8 +150,8 @@ html_theme_options = {
     'github_banner': True,
     'show_powered_by': False,
     'extra_nav_links': {
-        'zenodo@GitHub': 'http://github.com/zenodo/zenodo',
-        'zenodo@PyPI': 'http://pypi.python.org/pypi/zenodo/',
+        'zenodo@GitHub': 'https://github.com/zenodo/zenodo',
+        'zenodo@PyPI': 'https://pypi.python.org/pypi/zenodo/',
     }
 }
 

--- a/zenodo/modules/theme/templates/zenodo_theme/footer.html
+++ b/zenodo/modules/theme/templates/zenodo_theme/footer.html
@@ -92,7 +92,7 @@
         </div>
       </div>
       <div class="col-xs-12 col-sm-6 col-sm-pull-6 text-center-xs">
-        <p>Powered by <a href="https://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> &amp; <a href="http://inveniosoftware.org">Invenio</a></p>
+        <p>Powered by <a href="https://home.cern/science/computing/data-centre">CERN Data Centre</a> &amp; <a href="http://inveniosoftware.org">Invenio</a></p>
       </div>
     </div>
   </div>

--- a/zenodo/modules/theme/templates/zenodo_theme/footer.html
+++ b/zenodo/modules/theme/templates/zenodo_theme/footer.html
@@ -60,7 +60,7 @@
             <div class="col-xs-2 col-md-2">
               <h5>{{_('Contribute')}}</h5>
               <ul class="list-unstyled">
-                <li><a href="http://github.com/zenodo/zenodo"><i class="fa fa-external-link"></i> {{_('GitHub')}}</a></li>
+                <li><a href="https://github.com/zenodo/zenodo"><i class="fa fa-external-link"></i> {{_('GitHub')}}</a></li>
                 <li><a href="/donate"><i class="fa fa-external-link"></i> {{_('Donate')}}</a></li>
               </ul>
             </div>
@@ -70,8 +70,8 @@
           <div class="pull-right-md text-center-sm text-center-xs">
             <h5>{{_('Funded by')}}</h5>
             <ul class="list-inline">
-              <li><a href="http://home.cern"><img src="{{ url_for('static', filename='img/cern.png') }}" width="60" height="60" /></a></li>
-              <li><a href="http://www.openaire.eu"><img src="{{ url_for('static', filename='img/openaire.png') }}" width="80" /></a></li>
+              <li><a href="https://home.cern"><img src="{{ url_for('static', filename='img/cern.png') }}" width="60" height="60" /></a></li>
+              <li><a href="https://www.openaire.eu"><img src="{{ url_for('static', filename='img/openaire.png') }}" width="80" /></a></li>
               <li><a href="https://ec.europa.eu/programmes/horizon2020/"><img src="{{ url_for('static', filename='img/eu.png') }}" width="88" height="60" /></a></li>
             </ul>
           </div>
@@ -92,7 +92,7 @@
         </div>
       </div>
       <div class="col-xs-12 col-sm-6 col-sm-pull-6 text-center-xs">
-        <p>Powered by <a href="http://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> &amp; <a href="http://inveniosoftware.org">Invenio</a></p>
+        <p>Powered by <a href="https://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> &amp; <a href="http://inveniosoftware.org">Invenio</a></p>
       </div>
     </div>
   </div>

--- a/zenodo/modules/theme/templates/zenodo_theme/security/register_user.html
+++ b/zenodo/modules/theme/templates/zenodo_theme/security/register_user.html
@@ -100,8 +100,8 @@
 <footer>
 <div>
   <ul class="list-inline">
-    <li><a href="http://www.openaire.eu"><img src="{{ url_for('static', filename='img/openaire.png') }}" width="80"></a></li>
-    <li><a href="http://home.cern"><img src="{{ url_for('static', filename='img/cern.png') }}"></a></li>
+    <li><a href="https://www.openaire.eu"><img src="{{ url_for('static', filename='img/openaire.png') }}" width="80"></a></li>
+    <li><a href="https://home.cern"><img src="{{ url_for('static', filename='img/cern.png') }}"></a></li>
     <li><a href="https://ec.europa.eu/programmes/horizon2020/"><img src="{{ url_for('static', filename='img/eu.png') }}"></a></li>
   </ul>
 </div>


### PR DESCRIPTION
Hello!

This updates some links the HTTPS version of sites that either forward automatically, or have it separately but working. Similarly, the old `dx.doi.org` is redirected automatically, but let's switch it to `https://doi.org` at the source.

About the `...API update`: In case the tests should cover the non-HTTPS links as well, please let me know and I'll revert those lines. If you on the other hand agree to only continue testing the HTTPS links, I would push another (few) commit(s). `d-nb.info` for example would be securely linked to at the source.

Cheers :-)