### PR TITLE
records: addition of 'identifier' to the schema.org serialization

### DIFF
--- a/tests/unit/records/test_schemas_schemaorg_jsonld.py
+++ b/tests/unit/records/test_schemas_schemaorg_jsonld.py
@@ -149,6 +149,7 @@ def test_minimal_software_record(minimal_record_model):
         u'@context': u'https://schema.org/',
         u'@id': 'https://doi.org/10.5072/zenodo.123',
         u'@type': u'SoftwareSourceCode',
+        u'identifier': 'https://doi.org/10.5072/zenodo.123',
         u'url': 'http://localhost/record/123',
         u'description': u'My description',
         u'codeRepository': 'https://github.com/orgname/reponame/tree/v0.1.0',
@@ -176,6 +177,7 @@ def test_full_record(record_with_files_creation):
         u'@context': u'https://schema.org/',
         u'@id': 'https://doi.org/10.1234/foo.bar',
         u'@type': u'Book',
+        u'identifier': 'https://doi.org/10.1234/foo.bar',
         u'about': [
             {
                 u'@id': u'http://id.loc.gov/authorities/subjects/sh85009003',

--- a/zenodo/modules/records/serializers/schemas/schemaorg.py
+++ b/zenodo/modules/records/serializers/schemas/schemaorg.py
@@ -37,7 +37,7 @@ from .common import format_pid_link
 
 
 def _serialize_identifiers(ids, relations=None):
-    """Serialize identifiers to URLs.
+    """Serialize related and alternate identifiers to URLs.
 
     :param ids: List of related_identifier or alternate_identifier objects.
     :param relations: if not None, will only select IDs of specific relation
@@ -104,7 +104,8 @@ class CreativeWork(Schema):
 
     CONTEXT = "https://schema.org/"
 
-    doi = fields.Method('get_doi', dump_to='@id')
+    identifier = fields.Method('get_doi', dump_to='identifier')
+    id_ = fields.Method('get_doi', dump_to='@id')
 
     # NOTE: use `__class__`?
     type_ = fields.Method('get_type', dump_to='@type')


### PR DESCRIPTION
* Record DOI is now serialized both as '@id' and 'identifier'.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>