### PR TITLE
base-v1.0.0.json: Fix typo in relation_type enum ("isOrignialFormof")

### DIFF
--- a/zenodo/modules/records/jsonschemas/records/base-v1.0.0.json
+++ b/zenodo/modules/records/jsonschemas/records/base-v1.0.0.json
@@ -148,7 +148,7 @@
         "isCompiledBy",
         "compiles",
         "isVariantFormOf",
-        "isOrignialFormOf",
+        "isOriginalFormOf",
         "isIdenticalTo",
         "isReviewedBy",
         "reviews",


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo/issues/1366