### PR TITLE
exporter: request context independent url gen

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -167,6 +167,7 @@ def default_config(tmp_db_path):
         SQLALCHEMY_DATABASE_URI=os.environ.get(
             'SQLALCHEMY_DATABASE_URI', tmp_db_path),
         TESTING=True,
+        THEME_SITEURL='http://localhost',
         WTF_CSRF_ENABLED=False,
     )
 

--- a/tests/unit/exporter/conftest.py
+++ b/tests/unit/exporter/conftest.py
@@ -41,12 +41,13 @@ def bucket(db, locations):
 
 @pytest.fixture()
 def writer(bucket):
+    """Bucket writer object fixture."""
     return BucketWriter(bucket_id=bucket.id, key='test.json')
 
 
 @pytest.fixture()
 def searchobj():
-    """Search object"""
+    """Search object."""
     class Hit(dict):
         def __init__(self, *args, **kwargs):
             super(Hit, self).__init__(*args, **kwargs)
@@ -68,7 +69,7 @@ def searchobj():
 
 @pytest.fixture()
 def serializerobj():
-    """Serialize object"""
+    """Serialize object."""
     class Serializer(object):
         def serialize_exporter(self, pid, record):
             return record['_source']['title'].encode('utf8')
@@ -77,7 +78,7 @@ def serializerobj():
 
 @pytest.fixture()
 def fetcher():
-    """PID fetcher method"""
+    """PID fetcher method."""
     def fetcher(id_, data):
         return id_
     return fetcher
@@ -85,11 +86,11 @@ def fetcher():
 
 @pytest.fixture()
 def resultstream(searchobj, serializerobj, fetcher):
-    """Result stream"""
+    """Result stream."""
     return ResultStream(searchobj, fetcher, serializerobj)
 
 
 @pytest.fixture()
 def bzip2resultstream(searchobj, serializerobj, fetcher):
-    """BZip2 Result stream"""
+    """BZip2 Result stream."""
     return BZip2ResultStream(searchobj, fetcher, serializerobj)

--- a/tests/unit/sitemap/test_sitemap_generator.py
+++ b/tests/unit/sitemap/test_sitemap_generator.py
@@ -38,7 +38,7 @@ from zenodo.modules.sitemap.tasks import update_sitemap_cache
 def test_sitemap_cache_update_simple(mocker, app):
     """Test Sitemap cache updating with fixed parameters."""
     def make_url(loc):
-        return {'loc': 'https://zenodo.org' + loc}
+        return {'loc': 'https://localhost' + loc}
 
     urls = [make_url('/record/' + str(i)) for i in range(5)]
     cache_mock = mocker.patch('zenodo.modules.sitemap.ext.current_cache')

--- a/zenodo/modules/exporter/streams.py
+++ b/zenodo/modules/exporter/streams.py
@@ -46,6 +46,7 @@ class ResultStream(object):
     """
 
     def __init__(self, search, pid_fetcher, serializer):
+        """Initialize result stream."""
         self.pid_fetcher = pid_fetcher
         self.search = search
         self.serializer = serializer
@@ -90,10 +91,12 @@ class BZip2ResultStream(ResultStream):
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize result stream."""
         super(BZip2ResultStream, self).__init__(*args, **kwargs)
         self.compressor = bz2.BZ2Compressor()
 
     def __next__(self):
+        """Fetch next serialized bzip2 compressed chunk of records(s)."""
         try:
             data = None
             while not data:

--- a/zenodo/modules/exporter/tasks.py
+++ b/zenodo/modules/exporter/tasks.py
@@ -35,5 +35,8 @@ from .api import Exporter
 @shared_task
 def export_job(job_id=None):
     """Export job."""
-    job_definition = current_app.extensions['invenio-exporter'].job(job_id)
-    Exporter(**job_definition).run()
+    base_url = current_app.config['THEME_SITEURL']
+    # Execute in API request context, to enable proper URL generation.
+    with current_app.test_request_context(base_url):
+        job_definition = current_app.extensions['invenio-exporter'].job(job_id)
+        Exporter(**job_definition).run()

--- a/zenodo/modules/exporter/writers.py
+++ b/zenodo/modules/exporter/writers.py
@@ -36,6 +36,7 @@ class BucketWriter(object):
     """Export writer that writes to an object in a bucket."""
 
     def __init__(self, bucket_id=None, key=None, **kwargs):
+        """Initialize writer."""
         self.bucket_id = bucket_id
         self.key = key
         self.obj = None

--- a/zenodo/modules/records/serializers/schemas/json.py
+++ b/zenodo/modules/records/serializers/schemas/json.py
@@ -26,7 +26,6 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-from flask import url_for
 from flask_babelex import lazy_gettext as _
 from invenio_pidrelations.serializers.utils import serialize_relations
 from marshmallow import Schema, ValidationError, fields, missing, \
@@ -137,14 +136,7 @@ class FunderSchemaV1(StrictKeysSchema):
 
     def get_funder_url(self, obj):
         """Get grant url."""
-        try:
-            return dict(self=url_for(
-                'invenio_records_rest.frdoi_item',
-                pid_value=obj['doi'],
-                _external=True
-            ))
-        except BuildError:
-            return missing
+        return dict(self=common.api_link_for('funder', id=obj['doi']))
 
 
 class GrantSchemaV1(StrictKeysSchema):
@@ -159,14 +151,7 @@ class GrantSchemaV1(StrictKeysSchema):
 
     def get_grant_url(self, obj):
         """Get grant url."""
-        try:
-            return dict(self=url_for(
-                'invenio_records_rest.grant_item',
-                pid_value=obj['internal_id'],
-                _external=True
-            ))
-        except BuildError:
-            return missing
+        return dict(self=common.api_link_for('grant', id=obj['internal_id']))
 
 
 class CommunitiesSchemaV1(StrictKeysSchema):
@@ -193,17 +178,10 @@ class FilesSchema(Schema):
 
     def get_links(self, obj):
         """Get links."""
-        try:
-            return {
-                'self': url_for(
-                    'invenio_files_rest.object_api',
-                    bucket_id=obj['bucket'],
-                    key=obj['key'],
-                    _external=True
-                )
-            }
-        except (BuildError, KeyError):
-            return missing
+        return {
+            'self': common.api_link_for(
+                'object', bucket=obj['bucket'], key=obj['key'])
+        }
 
 
 class OwnerSchema(StrictKeysSchema):


### PR DESCRIPTION
* Removes necessity to have a request context in order to generate
  URLs when serializing records.