### PR TITLE
stats: aggregations fault tolerance increase

### DIFF
--- a/tests/unit/stats/test_stats_aggs.py
+++ b/tests/unit/stats/test_stats_aggs.py
@@ -90,8 +90,12 @@ def test_large_stats(app, db, es, locations, event_queues, minimal_record):
 
     # Aggregations indices
     # (4 versions + 1 concept) * 3 records -> 15 documents + 2 bookmarks
-    assert search.index('stats-file-download').count() == 933  # 2bm + 30d
-    assert search.index('stats-record-view').count() == 933  # 2bm + 30d
+    q = search.index('stats-file-download')
+    q = q.doc_type('file-download-day-aggregation')
+    assert q.count() == 915  # 61 days * 15 records
+    q = search.index('stats-record-view')
+    q = q.doc_type('record-view-day-aggregation')
+    assert q.count() == 915  # 61 days * 15 records
 
     # Reords index
     for _, record, _ in records:

--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -67,6 +67,7 @@ from zenodo_accessrequests.config import ACCESSREQUESTS_RECORDS_UI_ENDPOINTS
 from zenodo.modules.records.permissions import deposit_delete_permission_factory, \
     deposit_read_permission_factory, deposit_update_permission_factory, \
     record_create_permission_factory
+from zenodo.modules.stats import current_stats_search_client
 
 
 def _(x):
@@ -1255,9 +1256,11 @@ STATS_AGGREGATIONS = {
     'record-view-agg': dict(
         templates='zenodo.modules.stats.templates.aggregations',
         aggregator_config=dict(
+            client=current_stats_search_client,
             event='record-view',
             aggregation_field='recid',
             aggregation_interval='day',
+            batch_size=1,
             copy_fields=dict(
                 record_id='record_id',
                 recid='recid',

--- a/zenodo/modules/records/serializers/schemas/datacite.py
+++ b/zenodo/modules/records/serializers/schemas/datacite.py
@@ -26,11 +26,11 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-from flask import current_app
 import json
 
 import arrow
 import pycountry
+from flask import current_app
 from marshmallow import Schema, fields, post_dump
 
 from zenodo.modules.openaire.helpers import openaire_community_identifier, \

--- a/zenodo/modules/stats/__init__.py
+++ b/zenodo/modules/stats/__init__.py
@@ -23,3 +23,11 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Zenodo statistics module."""
+
+from __future__ import absolute_import, print_function
+
+from .proxies import current_stats_search_client
+
+__all__ = (
+    'current_stats_search_client',
+)

--- a/zenodo/modules/stats/ext.py
+++ b/zenodo/modules/stats/ext.py
@@ -26,6 +26,11 @@
 
 from __future__ import absolute_import, print_function
 
+from elasticsearch import Elasticsearch
+from elasticsearch.connection import RequestsHttpConnection
+from flask import current_app
+from werkzeug.utils import cached_property
+
 from . import config
 
 
@@ -36,6 +41,16 @@ class ZenodoStats(object):
         """Extension initialization."""
         if app:
             self.init_app(app)
+
+    @cached_property
+    def search_client(self):
+        """Elasticsearch client for stats queries."""
+        client_config = current_app.config.get(
+            'ZENODO_STATS_ELASTICSEARCH_CLIENT_CONFIG') or {}
+        client_config.setdefault(
+            'hosts', current_app.config.get('SEARCH_ELASTIC_HOSTS'))
+        client_config.setdefault('connection_class', RequestsHttpConnection)
+        return Elasticsearch(**client_config)
 
     @staticmethod
     def init_config(app):

--- a/zenodo/modules/stats/proxies.py
+++ b/zenodo/modules/stats/proxies.py
@@ -22,17 +22,13 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Configuration for Zenodo stats."""
+"""Proxies for Zenodo stats module."""
 
-ZENODO_STATS_PIWIK_EXPORTER = {
-    'id_site': 1,
-    'url': 'https://analytics.openaire.eu/piwik.php',
-    'token_auth': 'api-token',
-    'chunk_size': 85  # [max piwik payload size = 64k] / [max querystring size = 750]
-}
+from __future__ import absolute_import, print_function
 
-ZENODO_STATS_PIWIK_EXPORT_ENABLED = True
+from flask import current_app
+from werkzeug.local import LocalProxy
 
-# Queries performed when processing aggregations might take more time than
-# usual. This is fine though, since this is happening during Celery tasks.
-ZENODO_STATS_ELASTICSEARCH_CLIENT_CONFIG = {'timeout': 30}
+current_stats_search_client = LocalProxy(
+    lambda: current_app.extensions['zenodo-stats'].search_client)
+"""Proxy to Elasticsearch client used for statistics queries."""

--- a/zenodo/modules/stats/registrations.py
+++ b/zenodo/modules/stats/registrations.py
@@ -26,9 +26,10 @@
 
 from flask_principal import ActionNeed
 from invenio_access.permissions import Permission
-from invenio_search import current_search_client
 from invenio_stats.aggregations import StatAggregator
 from invenio_stats.queries import ESTermsQuery
+
+from .proxies import current_stats_search_client
 
 
 def register_aggregations():
@@ -38,10 +39,11 @@ def register_aggregations():
         templates='zenodo.modules.stats.templates.aggregations',
         aggregator_class=StatAggregator,
         aggregator_config=dict(
-            client=current_search_client,
+            client=current_stats_search_client,
             event='file-download',
             aggregation_field='recid',
             aggregation_interval='day',
+            batch_size=1,
             copy_fields=dict(
                 bucket_id='bucket_id',
                 record_id='record_id',
@@ -65,10 +67,11 @@ def register_aggregations():
             templates='zenodo.modules.stats.templates.aggregations',
             aggregator_class=StatAggregator,
             aggregator_config=dict(
-                client=current_search_client,
+                client=current_stats_search_client,
                 event='file-download',
                 aggregation_field='conceptrecid',
                 aggregation_interval='day',
+                batch_size=1,
                 copy_fields=dict(
                     conceptrecid='conceptrecid',
                     conceptdoi='conceptdoi',
@@ -91,10 +94,11 @@ def register_aggregations():
             templates='zenodo.modules.stats.templates.aggregations',
             aggregator_class=StatAggregator,
             aggregator_config=dict(
-                client=current_search_client,
+                client=current_stats_search_client,
                 event='record-view',
                 aggregation_field='conceptrecid',
                 aggregation_interval='day',
+                batch_size=1,
                 copy_fields=dict(
                     conceptrecid='conceptrecid',
                     conceptdoi='conceptdoi',


### PR DESCRIPTION
* Uses a custom Elastricsearch client with increased request timeout
  when processing aggregations.
* Decreases days batch size for aggregation queries (creating buckets
  for 1 day vs. 7 days).