### PR TITLE
types: add two publication subtypes

### DIFF
--- a/zenodo/modules/deposit/jsonschemas/deposits/records/legacyrecord.json
+++ b/zenodo/modules/deposit/jsonschemas/deposits/records/legacyrecord.json
@@ -355,6 +355,8 @@
           "thesis",
           "technicalnote",
           "workingpaper",
+          "datamanagementplan",
+          "annotationcollection",
           "other"
         ],
         "type": "string"

--- a/zenodo/modules/deposit/static/json/zenodo_deposit/deposit_form.json
+++ b/zenodo/modules/deposit/static/json/zenodo_deposit/deposit_form.json
@@ -77,6 +77,10 @@
         "condition": "model.upload_type == 'publication'",
         "titleMap": [
           {
+            "value": "annotationcollection",
+            "name": "Annotation collection"
+          },
+          {
             "value": "book",
             "name": "Book"
           },
@@ -87,6 +91,10 @@
           {
             "value": "conferencepaper",
             "name": "Conference paper"
+          },
+          {
+            "value": "datamanagementplan",
+            "name": "Data management plan"
           },
           {
             "value": "article",

--- a/zenodo/modules/records/data/objecttypes.json
+++ b/zenodo/modules/records/data/objecttypes.json
@@ -23,7 +23,9 @@
     {"$ref": "https://zenodo.org/objecttypes/publication/thesis"},
     {"$ref": "https://zenodo.org/objecttypes/publication/technicalnote"},
     {"$ref": "https://zenodo.org/objecttypes/publication/workingpaper"},
-    {"$ref": "https://zenodo.org/objecttypes/publication/other"}
+    {"$ref": "https://zenodo.org/objecttypes/publication/other"},
+    {"$ref": "https://zenodo.org/objecttypes/publication/datamanagementplan"},
+    {"$ref": "https://zenodo.org/objecttypes/publication/annotationcollection"}
   ],
   "openaire": {
     "resourceType": "0001",
@@ -602,4 +604,44 @@
     "type": "publication"
   },
   "csl": "graphic"
+},
+{
+  "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+  "internal_id": "publication-datamanagementplan",
+  "id": "https://zenodo.org/objecttypes/publication/datamanagementplan#",
+  "title": {
+    "en": "Data management plan"
+  },
+  "title_plural": {
+    "en": "Data management plans"
+  },
+  "schema.org": "https://schema.org/CreativeWork",
+  "datacite": {"general": "Text", "type": "Data Management Plan"},
+  "eurepo": "info:eu-repo/semantics/technicalDocumentation",
+  "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+  "openaire": {
+    "resourceType": "0009",
+    "type": "publication"
+  },
+  "csl": "report"
+},
+{
+  "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+  "internal_id": "publication-annotationcollection",
+  "id": "https://zenodo.org/objecttypes/publication/annotationcollection#",
+  "title": {
+    "en": "Annotation Collection"
+  },
+  "title_plural": {
+    "en": "Annotation Collections"
+  },
+  "schema.org": "https://schema.org/Collection",
+  "datacite": {"general": "Collection"},
+  "eurepo": "info:eu-repo/semantics/technicalDocumentation",
+  "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+  "openaire": {
+    "resourceType": "0009",
+    "type": "publication"
+  },
+  "csl": "report"
 }]


### PR DESCRIPTION
* close #1726

In order to review the choices made for the different fields, here is the list of the specifications for each of them

``"schema.org":`` https://schema.org/docs/full.html

``"datacite":`` https://schema.datacite.org/meta/kernel-4.2/doc/DataCite-MetadataKernel_v4.2.pdf

``"openaire":``  from https://github.com/zenodo/zenodo/issues/1270

``"csl":`` from https://github.com/citation-style-language/documentation/blob/master/specification.txt

Appendix III - Types
--------------------

-  article
-  article-magazine
-  article-newspaper
-  article-journal
-  bill
-  book
-  broadcast
-  chapter
-  dataset
-  entry
-  entry-dictionary
-  entry-encyclopedia
-  figure
-  graphic
-  interview
-  legislation
-  legal\_case
-  manuscript
-  map
-  motion\_picture
-  musical\_score
-  pamphlet
-  paper-conference
-  patent
-  post
-  post-weblog
-  personal\_communication
-  report
-  review
-  review-book
-  song
-  speech
-  thesis
-  treaty
-  webpage
