### PR TITLE
stats: add es prefix support in templates

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -202,6 +202,7 @@ def default_config(tmp_db_path):
                 }
             }
         },
+        SEARCH_INDEX_PREFIX='zenodo-test-',
     )
 
 

--- a/tests/unit/deposit/test_deposit_index.py
+++ b/tests/unit/deposit/test_deposit_index.py
@@ -31,6 +31,7 @@ from invenio_pidrelations.contrib.versioning import PIDVersioning
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from invenio_records.api import Record
 from invenio_search import current_search
+from invenio_search.api import RecordsSearch
 from six import BytesIO, b
 
 from zenodo.modules.deposit.api import ZenodoDeposit
@@ -65,7 +66,7 @@ def test_deposit_index(db, es):
     })
     db.session.commit()
     current_search.flush_and_refresh(deposit_index_name)
-    res = current_search.client.search(index=deposit_index_name)
+    res = RecordsSearch(index=deposit_index_name).execute()
     # Make sure the 'title' was indexed from record
     assert res['hits']['hits'][0]['_source']['title'] == 'One'
 
@@ -84,10 +85,9 @@ def test_versioning_indexing(db, es, deposit, deposit_file):
     RecordIndexer().process_bulk_queue()
     current_search.flush_and_refresh(index=deposit_index_name)
     current_search.flush_and_refresh(index=records_index_name)
-    s_dep = current_search.client.search(
-        index=deposit_index_name)['hits']['hits']
-    s_rec = current_search.client.search(
-        index=records_index_name)['hits']['hits']
+    s_dep = RecordsSearch(index=deposit_index_name).execute()['hits']['hits']
+    s_rec = RecordsSearch(index=records_index_name).execute()['hits']['hits']
+
     assert len(s_dep) == 1
     assert len(s_rec) == 1
     assert 'relations' in s_dep[0]['_source']
@@ -124,10 +124,8 @@ def test_versioning_indexing(db, es, deposit, deposit_file):
     RecordIndexer().process_bulk_queue()
     current_search.flush_and_refresh(index=deposit_index_name)
     current_search.flush_and_refresh(index=records_index_name)
-    s_dep = current_search.client.search(
-        index=deposit_index_name)['hits']['hits']
-    s_rec = current_search.client.search(
-        index=records_index_name)['hits']['hits']
+    s_dep = RecordsSearch(index=deposit_index_name).execute()['hits']['hits']
+    s_rec = RecordsSearch(index=records_index_name).execute()['hits']['hits']
 
     assert len(s_dep) == 2  # Two deposits should be indexed
     assert len(s_rec) == 1  # One, since record does not exist yet
@@ -193,10 +191,8 @@ def test_versioning_indexing(db, es, deposit, deposit_file):
     current_search.flush_and_refresh(index=deposit_index_name)
     current_search.flush_and_refresh(index=records_index_name)
 
-    s_dep = current_search.client.search(
-        index=deposit_index_name)['hits']['hits']
-    s_rec = current_search.client.search(
-        index=records_index_name)['hits']['hits']
+    s_dep = RecordsSearch(index=deposit_index_name).execute()['hits']['hits']
+    s_rec = RecordsSearch(index=records_index_name).execute()['hits']['hits']
     assert len(s_dep) == 2
     assert len(s_rec) == 2
 

--- a/tests/unit/github/test_github_tasks.py
+++ b/tests/unit/github/test_github_tasks.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Test celery tasks for GitHub."""
+
+from datetime import datetime
+
+from zenodo.modules.github.tasks import find_not_synced_remote_accounts
+
+
+def test_github_sync(mocker, db, g_users, g_repositories, g_remoteaccounts):
+    find_not_synced_remote_accounts(1)

--- a/tests/unit/stats/test_event_emitters.py
+++ b/tests/unit/stats/test_event_emitters.py
@@ -47,7 +47,8 @@ def test_record_page(app, db, es, event_queues, full_record):
     process_events(['record-view'])
     current_search.flush_and_refresh(index='events-stats-record-view')
 
-    search = Search(using=es, index='events-stats-record-view')
+    prefix = app.config['SEARCH_INDEX_PREFIX']
+    search = Search(using=es, index=prefix+'events-stats-record-view')
     assert search.count() == 1
     doc = search.execute()[0]
     assert doc['doi'] == '10.1234/foo.bar'
@@ -79,7 +80,8 @@ def test_file_download(app, db, es, event_queues, record_with_files_creation):
     process_events(['file-download'])
     current_search.flush_and_refresh(index='events-stats-file-download')
 
-    search = Search(using=es, index='events-stats-file-download')
+    prefix = app.config['SEARCH_INDEX_PREFIX']
+    search = Search(using=es, index=prefix+'events-stats-file-download')
     assert search.count() == 1
     doc = search.execute()[0]
     assert doc['doi'] == '10.1234/foo.bar'

--- a/tests/unit/stats/test_stats_aggs.py
+++ b/tests/unit/stats/test_stats_aggs.py
@@ -40,18 +40,23 @@ def test_basic_stats(app, db, es, locations, event_queues, minimal_record):
         start_date=datetime(2018, 1, 1, 13),
         end_date=datetime(2018, 1, 1, 15),
         interval=timedelta(minutes=30))
+
     # Events indices
+    prefix = app.config['SEARCH_INDEX_PREFIX']
+
     # 2 versions * 10 records * 3 files * 4 events -> 240
-    assert search.index('events-stats-file-download').count() == 240
+    assert search.index(prefix + 'events-stats-file-download').count() == 240
     # 2 versions * 10 records * 4 events -> 80
-    assert search.index('events-stats-record-view').count() == 80
+    assert search.index(prefix + 'events-stats-record-view').count() == 80
 
     # Aggregations indices
     # (2 versions + 1 concept) * 10 records -> 30 documents + 2 bookmarks
-    assert search.index('stats-file-download').count() == 32  # 2bm + 30d
-    assert search.index('stats-record-view').count() == 32  # 2bm + 30d
+    assert search.index(prefix + 'stats-file-download').count() == 32  # 2bm + 30d
+    assert search.index(prefix + 'stats-record-view').count() == 32  # 2bm + 30d
 
-    # Reords index
+    # import wdb; wdb.set_trace()
+
+    # Records index
     for _, record, _ in records:
         doc = (
             RecordsSearch().get_record(record.id)
@@ -83,19 +88,23 @@ def test_large_stats(app, db, es, locations, event_queues, minimal_record):
         interval=timedelta(hours=12))
 
     # Events indices
+    prefix = app.config['SEARCH_INDEX_PREFIX']
+
     # 4 versions * 3 records * 2 files * 122 events -> 2928
-    assert search.index('events-stats-file-download').count() == 2928
+    assert search.index(prefix + 'events-stats-file-download').count() == 2928
     # 4 versions * 3 records * 122 events -> 1464
-    assert search.index('events-stats-record-view').count() == 1464
+    assert search.index(prefix + 'events-stats-record-view').count() == 1464
 
     # Aggregations indices
     # (4 versions + 1 concept) * 3 records -> 15 documents + 2 bookmarks
-    q = search.index('stats-file-download')
+    q = search.index(prefix + 'stats-file-download')
     q = q.doc_type('file-download-day-aggregation')
     assert q.count() == 915  # 61 days * 15 records
-    q = search.index('stats-record-view')
+    q = search.index(prefix + 'stats-record-view')
     q = q.doc_type('record-view-day-aggregation')
     assert q.count() == 915  # 61 days * 15 records
+
+    # import wdb; wdb.set_trace()
 
     # Reords index
     for _, record, _ in records:

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -24,7 +24,7 @@
 
 """Basics tests to ensure DB and Elasticsearch is running."""
 
-from invenio_search import current_search_client
+from invenio_search import current_search_client, current_search
 
 
 def test_es_running(app):
@@ -34,37 +34,62 @@ def test_es_running(app):
 
 def test_es_state(app, es):
     """Test generated mappings, templates and aliases on ElasticSearch."""
+    prefix = app.config['SEARCH_INDEX_PREFIX']
+    suffix = current_search._current_suffix
+
     assert current_search_client.indices.get_aliases() == {
-        'deposits-deposit-v1.0.0': {  # leftover from invenio-deposit
-            'aliases': {'deposits': {}}},
-        'deposits-records-record-v1.0.0': {
-            'aliases': {'deposits': {}, 'deposits-records': {}}},
-        'funders-funder-v1.0.0': {
-            'aliases': {'funders': {}}},
-        'grants-grant-v1.0.0': {
-            'aliases': {'grants': {}}},
-        'licenses-license-v1.0.0': {
-            'aliases': {'licenses': {}}},
-        'records-record-v1.0.0': {
-            'aliases': {'records': {}}},
-    }
+            prefix + 'grants-grant-v1.0.0' + suffix: {
+                'aliases': {
+                    prefix + 'grants': {},
+                    prefix + 'grants-grant-v1.0.0': {}
+                }
+            }, prefix + 'records-record-v1.0.0' + suffix: {
+                'aliases': {
+                    prefix + 'records': {},
+                    prefix + 'records-record-v1.0.0': {}
+                }
+            }, prefix + 'deposits-records-record-v1.0.0' + suffix: {
+                'aliases': {
+                    prefix + 'deposits-records-record-v1.0.0': {},
+                    prefix + 'deposits': {},
+                    prefix + 'deposits-records': {}
+                }
+            },  # leftover from invenio-deposit
+            prefix + 'deposits-deposit-v1.0.0' + suffix: {
+                'aliases': {
+                    prefix + 'deposits': {},
+                    prefix + 'deposits-deposit-v1.0.0': {}
+                }
+            }, prefix + 'licenses-license-v1.0.0' + suffix: {
+                'aliases': {
+                    prefix + 'licenses-license-v1.0.0': {},
+                    prefix + 'licenses': {}
+                }
+            }, prefix + 'funders-funder-v1.0.0' + suffix: {
+                'aliases': {
+                    prefix + 'funders': {},
+                    prefix + 'funders-funder-v1.0.0': {}
+                }
+            }
+        }
+
     templates = {
         k: (v['template'], set(v['aliases'].keys()), set(v['mappings'].keys()))
         for k, v in current_search_client.indices.get_template().items()
     }
     assert templates == {
-        'stats-templates-events/v2-record-view-v1.0.0': (
-            'events-stats-record-view-*',
+        prefix + 'stats-templates-events/v2-record-view-v1.0.0': (
+            prefix + 'events-stats-record-view-*',
             {'events-stats-record-view'},
             {'stats-record-view'},
         ),
-        'stats-templates-events/v2-file-download-v1.0.0': (
-            'events-stats-file-download-*',
+        prefix + 'stats-templates-events/v2-file-download-v1.0.0': (
+            prefix + 'events-stats-file-download-*',
             {'events-stats-file-download'},
             {'_default_', 'stats-file-download'},
         ),
-        'stats-templates-aggregations/v2-aggr-record-view-v1.0.0': (
-            'stats-record-view-*',
+        prefix + 'stats-templates-aggregations/v2-aggr-record-view-v1.0.0': (
+            prefix + 'stats-record-view-*',
             {'stats-record-view'},
             {
                 'record-view-day-aggregation',
@@ -73,8 +98,9 @@ def test_es_state(app, es):
             },
 
         ),
-        'stats-templates-aggregations/v2-aggr-record-download-v1.0.0': (
-            'stats-file-download-*',
+        prefix + 'stats-templates-aggregations/v2-aggr-record-download-v1.0.0':
+            (
+            prefix + 'stats-file-download-*',
             {'stats-file-download'},
             {
                 '_default_',

--- a/zenodo/config.py
+++ b/zenodo/config.py
@@ -1201,6 +1201,8 @@ SEARCH_MAPPINGS = [
     'licenses',
     'records',
 ]
+#: ElasticSearch index prefix
+SEARCH_INDEX_PREFIX = 'zenodo-dev-'
 
 # Communities
 # ===========

--- a/zenodo/modules/github/tasks.py
+++ b/zenodo/modules/github/tasks.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Zenodo.
+# Copyright (C) 2018 CERN.
+#
+# Zenodo is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Celery background tasks."""
+
+import arrow
+from celery import shared_task
+from invenio_db import db
+from invenio_github.api import GitHubAPI
+from invenio_oauthclient.models import RemoteAccount
+
+
+@shared_task(ignore_result=True)
+def sync_remote_accounts():
+    """Sync all remote accounts which haven't been synced in more than several months."""
+    # TODO:
+    # 1) fetch all Remote Accounts which haven't been synced in the last x months
+    # 2) sync the accounts
+    remote_accounts = find_not_synced_remote_accounts(1)
+    for remote_account in remote_accounts:
+        sync_remote_account.delay(remote_account.user_id)
+
+
+@shared_task(ignore_result=True)
+def sync_remote_account(user_id):
+    """Sync a remote account."""
+    gh_api = GitHubAPI(user_id=user_id)
+    gh_api.sync()
+
+
+def find_not_synced_remote_accounts(month):
+    import wdb; wdb.set_trace()
+    filtered_remote_accounts = []
+    all_remote_accounts = db.session.query(RemoteAccount).all()
+    # .filter(RemoteAccount.extra_data['last_sync'] < arrow.utcnow().replace(month=-month))
+
+    for remote_account in all_remote_accounts:
+        last_sync = arrow.get(remote_account.extra_data['last_sync'])
+        if remote_account.extra_data['last_sync'] and \
+            last_sync < arrow.utcnow().replace(months=-month):
+                filtered_remote_accounts.append(remote_account)
+
+    return filtered_remote_accounts

--- a/zenodo/modules/records/utils.py
+++ b/zenodo/modules/records/utils.py
@@ -48,7 +48,7 @@ def schema_prefix(schema):
     if not schema:
         return None
     index, doctype = schema_to_index(
-        schema, index_names=current_search.mappings.keys())
+        schema, index_names=current_search.mappings.keys(), prefixed=False)
     return index.split('-')[0]
 
 
@@ -174,7 +174,7 @@ def build_record_custom_fields(record):
     for term, value in custom_metadata.items():
         term_type = valid_terms.get(term)['term_type']
         if term_type:
-            # TODO: in the futurem also add "community"
+            # TODO: in the future also add "community"
             es_object = {'key': term, 'value': value}
             es_custom_field = custom_fields_mapping[term_type]
             es_custom_fields[es_custom_field].append(es_object)

--- a/zenodo/modules/stats/templates/aggregations/v2/aggr-record-download-v1.0.0.json
+++ b/zenodo/modules/stats/templates/aggregations/v2/aggr-record-download-v1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-file-download-*",
+  "template": "__SEARCH_INDEX_PREFIX__stats-file-download-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -102,6 +102,6 @@
     }
   },
   "aliases": {
-    "stats-file-download": {}
+    "__SEARCH_INDEX_PREFIX__stats-file-download": {}
   }
 }

--- a/zenodo/modules/stats/templates/aggregations/v2/aggr-record-view-v1.0.0.json
+++ b/zenodo/modules/stats/templates/aggregations/v2/aggr-record-view-v1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "template": "stats-record-view-*",
+  "template": "__SEARCH_INDEX_PREFIX__stats-record-view-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -81,6 +81,6 @@
     }
   },
   "aliases": {
-    "stats-record-view": {}
+    "__SEARCH_INDEX_PREFIX__stats-record-view": {}
   }
 }

--- a/zenodo/modules/stats/templates/events/v2/file-download-v1.0.0.json
+++ b/zenodo/modules/stats/templates/events/v2/file-download-v1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-file-download-*",
+  "template": "__SEARCH_INDEX_PREFIX__events-stats-file-download-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -123,6 +123,6 @@
     }
   },
   "aliases": {
-    "events-stats-file-download": {}
+    "__SEARCH_INDEX_PREFIX__events-stats-file-download": {}
   }
 }

--- a/zenodo/modules/stats/templates/events/v2/record-view-v1.0.0.json
+++ b/zenodo/modules/stats/templates/events/v2/record-view-v1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "template": "events-stats-record-view-*",
+  "template": "__SEARCH_INDEX_PREFIX__events-stats-record-view-*",
   "settings": {
     "index.mapper.dynamic": false,
     "index": {
@@ -94,6 +94,6 @@
     }
   },
   "aliases": {
-    "events-stats-record-view": {}
+    "__SEARCH_INDEX_PREFIX__events-stats-record-view": {}
   }
 }

--- a/zenodo/modules/stats/utils.py
+++ b/zenodo/modules/stats/utils.py
@@ -113,7 +113,7 @@ def build_record_stats(recid, conceptrecid):
 def get_record_stats(recordid, throws=True):
     """Fetch record statistics from Elasticsearch."""
     try:
-        res = (RecordsSearch()
+        res = (RecordsSearch(index='records')
                .source(include='_stats')  # only include "_stats" field
                .get_record(recordid)
                .execute())

--- a/zenodo/modules/utils/tasks.py
+++ b/zenodo/modules/utils/tasks.py
@@ -202,8 +202,8 @@ def repair_record_metadata(uuid):
 def remove_oaiset_spec(record_uuid, spec):
     """Remove the OAI spec from the record and commit."""
     rec = Record.get_record(record_uuid)
-    rec['_oai']['sets'] = sorted([s for s in rec['_oai'].get('sets', [])
-                                  if s != spec])
+    rec['_oai']['sets'] = sorted(set([s for s in rec['_oai'].get('sets', [])
+                                      if s != spec]))
     rec['_oai']['updated'] = datetime_to_datestamp(datetime.utcnow())
     if not rec['_oai']['sets']:
         del rec['_oai']['sets']
@@ -216,7 +216,7 @@ def remove_oaiset_spec(record_uuid, spec):
 def add_oaiset_spec(record_uuid, spec):
     """Add the OAI spec to the record and commit."""
     rec = Record.get_record(record_uuid)
-    rec['_oai']['sets'] = sorted(rec['_oai'].get('sets', []) + [spec, ])
+    rec['_oai']['sets'] = sorted(set(rec['_oai'].get('sets', []) + [spec, ]))
     rec['_oai']['updated'] = datetime_to_datestamp(datetime.utcnow())
     rec.commit()
     db.session.commit()
@@ -237,7 +237,7 @@ def iter_record_oai_tasks(query, spec, func):
         index=current_app.config['OAISERVER_RECORD_INDEX'],
     ).query(query)
     for result in search.scan():
-        yield func.s(result.meta.id, spec)
+        yield func.si(result.meta.id, spec)
 
 
 def make_oai_task_group(oais):


### PR DESCRIPTION
You should temporarily add the index prefix to the `SEARCH_MAPPINGS` in `config.py` in order to get the indeces created when you are using the lastest version of `invenio-search`:
``` python
SEARCH_MAPPINGS = [
    'zenodo-dev-deposits',
    'zenodo-dev-funders',
    'zenodo-dev-grants',
    'zenodo-dev-licenses',
    'zenodo-dev-records',
]
```

Edit: The problem has been fixed in the latest version of `invenio-search`.

To make the tests pass locally, install the following packages:
- invenio-search v1.2.2
- invenio-indexer v1.1.0
- invenio-previewer v1.0.0a11
- invenio-rest v1.1.1
- master branch of [invenio-deposit](https://github.com/inveniosoftware/invenio-deposit)
- master branch of [invenio-records-rest](https://github.com/inveniosoftware/invenio-records-rest)
- master branch of [invenio-opendefiniton](https://github.com/inveniosoftware/invenio-opendefinition)
- master branch of [ invenio-stats]( https://github.com/inveniosoftware/invenio-stats)
- https://github.com/inveniosoftware/invenio-openaire/pull/59
- https://github.com/inveniosoftware/invenio-communities/pull/123
- invenio-pidrelations==1.0.0a4
