### PR TITLE
github: fix communities getting removed from github records

### DIFF
--- a/zenodo/modules/github/api.py
+++ b/zenodo/modules/github/api.py
@@ -107,6 +107,9 @@ class ZenodoGitHubRelease(GitHubRelease):
                     last_deposit = last_deposit.registerconceptdoi()
                     last_recid, last_record = last_deposit.fetch_published()
                 deposit_metadata['conceptdoi'] = last_record['conceptdoi']
+                if last_record.get('communities'):
+                    deposit_metadata.setdefault('communities',
+                                                last_record['communities'])
                 if versioning.draft_child:
                     stashed_draft_child = versioning.draft_child
                     versioning.remove_draft_child()


### PR DESCRIPTION
Currently, when populating the metadata of the new release we are omitting the field ```communities``` which causes, due to ```_sync_communities```, the removal of the communities from every previous version.
Issue: https://github.com/zenodo/zenodo/issues/1795