### PR TITLE
deposit-ui: makes the displayed size limit dynamic

### DIFF
--- a/zenodo/modules/deposit/static/js/zenodo_deposit/filters.js
+++ b/zenodo/modules/deposit/static/js/zenodo_deposit/filters.js
@@ -120,6 +120,36 @@ function formatOpenAIRECommunities() {
   };
 }
 
+function fileSizeFormat() {
+
+  function filter(size) {
+    function round(num, precision) {
+      return Math.round(
+        num * Math.pow(10, precision)) / Math.pow(10, precision
+      );
+    }
+    var limit = Math.pow(1000, 4);
+    if (size > limit) {
+      return round(size / limit, 1) + ' TB';
+    } else if (size > (limit/=1000)) {
+      return round(size / limit, 1) + ' GB';
+    } else if (size > (limit/=1000)) {
+      return round(size / limit, 1) + ' MB';
+    } else if (size > 1000) {
+      return Math.round(size / 1000) +  ' kB';
+    }
+    if (size === 1) {
+      return "1 Byte"
+    }
+    return size + ' Bytes';
+  }
+
+  ////////////
+
+  return filter;
+}
+
+
 angular.module('invenioRecords')
   .filter('fieldtitle', fieldtitle)
   .filter('notIn', notIn)
@@ -128,4 +158,5 @@ angular.module('invenioRecords')
   .filter('striptags', striptags)
   .filter('stable', stable)
   .filter('checkAllFilesUploaded',checkAllFilesUploaded)
-  .filter('formatOpenAIRECommunities', formatOpenAIRECommunities);
+  .filter('formatOpenAIRECommunities', formatOpenAIRECommunities)
+  .filter('fileSizeFormat', fileSizeFormat);

--- a/zenodo/modules/deposit/static/templates/zenodo_deposit/list.html
+++ b/zenodo/modules/deposit/static/templates/zenodo_deposit/list.html
@@ -56,7 +56,7 @@
         <span ng-hide="f.links.self">{{ f.key | limitTo:50 }} <span ng-show="f.key.length > 50">...</span></span>
         <small class="text-muted" ng-show="f.checksum"><br />{{f.checksum}} <i class="fa fa-question-circle" data-placement="top" bs-tooltip data-container="div" data-title="This is the file fingerprint (MD5 checksum), which can be used to verify the file integrity."></i></small>
       </td>
-      <td>{{ f.size | bytesToHumanReadable }}</td>
+      <td>{{ f.size | fileSizeFormat }}</td>
       <td class="text-center">
         <span ng-show="f.progress < 100 && !f.errored">{{ f.progress }} %</span>
         <span ng-show="f.processing && !f.errored">Processing...</span>
@@ -98,8 +98,12 @@
 
   <p class="text-center" ng-hide="collapsed">
     <small class="text-muted">
-    (minimum 1 file required, max 50 GB per dataset - <a target="_blank" rel="noopener noreferrer" href="/contact">contact us</a> for larger datasets)
+      (minimum 1 file required, max {{ recordsVM.invenioRecordsArgs.templateParams.max_bucket_size | fileSizeFormat }} per dataset - <a target="_blank" rel="noopener noreferrer" href="/support">contact us</a> for larger datasets)
     </small>
+  </p>
+  <p class="text-center" ng-hide="collapsed">
+    <small>
+      If you're experiencing issues with uploading larger files, read our <a target="_blank" rel="noopener noreferrer" href="https://help.zenodo.org/">FAQ section</a> on file upload issues.</small>
   </p>
 </div>
 <div
@@ -130,7 +134,7 @@
         <a ng-show="f.links.self" ng-href="{{f.links.self}}">{{ f.key | limitTo:50 }} <span ng-show="f.key.length > 50">...</span></a>
         <span ng-hide="f.links.self">{{ f.key | limitTo:50 }} <span ng-show="f.key.length > 50">...</span></span>
       </td>
-      <td>{{ f.size | bytesToHumanReadable }}</td>
+      <td>{{ f.size | fileSizeFormat }}</td>
       <td><small class="text-muted">{{ f.checksum }}</small></td>
     </tr>
     <tr ng-show="(filesVM.files | filter:fileSearch).length == 0">

--- a/zenodo/modules/deposit/templates/zenodo_deposit/edit.html
+++ b/zenodo/modules/deposit/templates/zenodo_deposit/edit.html
@@ -88,7 +88,8 @@
   'has_versioning_permissions': has_versioning_permissions or False,
   'has_new_version_deposit': has_new_version_deposit or False,
   'newversionmodal_template': url_for('static', filename='templates/zenodo_deposit/neweversionmodal.html'),
-  'upgradeversioningmodal_template': url_for('static', filename='templates/zenodo_deposit/upgradeversioningmodal.html')
+  'upgradeversioningmodal_template': url_for('static', filename='templates/zenodo_deposit/upgradeversioningmodal.html'),
+  'max_bucket_size': record.files.bucket.quota_size if record.files else 50000000000
 } %}
 
 

--- a/zenodo/modules/theme/templates/zenodo_theme/footer.html
+++ b/zenodo/modules/theme/templates/zenodo_theme/footer.html
@@ -48,6 +48,7 @@
               <ul class="list-unstyled">
                 <li><a href="http://help.zenodo.org">{{_('FAQ')}}</a></li>
                 <li><a href="http://help.zenodo.org/features">{{_('Features')}}</a></li>
+                <li><a href="{{ url_for('zenodo_support.support')}}">{{_('Support')}}</a></li>
               </ul>
             </div>
             <div class="col-xs-2 col-md-2">


### PR DESCRIPTION
* Changes display file size measurement unit to ^10 instead of ^2
* Adds additional support link in the footer