### PR TITLE
deposit: allow HTML tables

### DIFF
--- a/zenodo/modules/deposit/static/json/zenodo_deposit/deposit_form.json
+++ b/zenodo/modules/deposit/static/json/zenodo_deposit/deposit_form.json
@@ -289,7 +289,7 @@
                 ["PasteText", "PasteFromWord"],
                 ["Bold", "Italic", "Strike", "Subscript", "Superscript"],
                 ["Link", "Unlink"],
-                ["NumberedList", "BulletedList", "Outdent", "Indent", "Blockquote", "CodeSnippet"],
+                ["NumberedList", "BulletedList", "Outdent", "Indent", "Blockquote", "Table", "CodeSnippet"],
                 ["Undo", "Redo", "Find", "Replace", "RemoveFormat"],
                 ["Mathjax", "SpecialChar"],
                 ["Source"], ["Maximize"]
@@ -368,12 +368,37 @@
         ]
       },
       {
-        "type": "textarea",
-        "key": "notes",
-        "title": "Additional notes",
-        "description": "Optional.",
-        "fa_cls": "fa-pencil",
-        "required": false
+        "type": "section",
+        "htmlClass": "form-ckeditor",
+        "description": "",
+        "notitle": true,
+        "items": [
+          {
+            "type": "ckeditor",
+            "key": "notes",
+            "title": "Additional notes",
+            "ckeditor": {
+              "height": 200,
+              "toolbar": [
+                ["PasteText", "PasteFromWord"],
+                ["Bold", "Italic", "Strike", "Subscript", "Superscript"],
+                ["Link", "Unlink"],
+                ["NumberedList", "BulletedList", "Outdent", "Indent", "Blockquote", "Table", "CodeSnippet"],
+                ["Undo", "Redo", "Find", "Replace", "RemoveFormat"],
+                ["Mathjax", "SpecialChar"],
+                ["Source"], ["Maximize"]
+              ],
+              "extraPlugins": "codesnippet,blockquote,mathjax",
+              "disableNativeSpellChecker": false,
+              "removePlugins": "elementspath",
+              "removeButtons": ""
+            },
+            "fa_cls": "fa-pencil",
+            "description": "Optional.",
+            "required": false,
+            "minLength": 1
+          }
+        ]
       }
     ]
   },

--- a/zenodo/modules/records/serializers/fields/html.py
+++ b/zenodo/modules/records/serializers/fields/html.py
@@ -29,7 +29,6 @@ from __future__ import absolute_import, print_function
 import bleach
 
 from .sanitizedunicode import SanitizedUnicode
-
 ALLOWED_TAGS = [
             'a',
             'abbr',
@@ -38,6 +37,7 @@ ALLOWED_TAGS = [
             'blockquote',
             'br',
             'code',
+            'caption',
             'div',
             'em',
             'i',
@@ -50,13 +50,26 @@ ALLOWED_TAGS = [
             'strong',
             'sub',
             'sup',
+            'table',
+            'tbody',
+            'thead',
+            'th',
+            'td',
+            'tr',
             'u',
             'ul',
         ]
 
 ALLOWED_ATTRS = {
             '*': ['class'],
-            'a': ['href', 'title', 'name', 'class', 'rel'],
+            'a': ['href', 'title', 'name', 'rel'],
+            'table': ['title',  'align', 'summary'],
+            'caption': ['class'],
+            'thead': ['title', 'align'],
+            'tbody': ['title', 'align'],
+            'th': ['title', 'scope'],
+            'td': ['title'],
+            'tr': ['title'],
             'abbr': ['title'],
             'acronym': ['title'],
         }

--- a/zenodo/modules/records/templates/zenodo_records/record_detail.html
+++ b/zenodo/modules/records/templates/zenodo_records/record_detail.html
@@ -72,9 +72,9 @@
         <h5>{{_('Thesis supervisor(s)')}}</h5>
         <p>{{ authors(record.thesis.supervisors) }}</p>
       {%- endif %}
-      <p>{{ record.description|safe }}</p>
+      <div class="record-description">{{ record.description|safe }}</div>
       {%- if record.notes %}
-      <div class="alert alert-warning">
+      <div class="alert alert-warning record-notes">
         {{ record.notes|safe}}
       </div>
       {%- endif %}

--- a/zenodo/modules/theme/static/scss/record.scss
+++ b/zenodo/modules/theme/static/scss/record.scss
@@ -305,3 +305,15 @@
     font-size: 36px;
   }
 }
+
+.record-description, .record-notes {
+  table {
+    margin: 1rem 0;
+  }
+
+  th, td {
+    border-style: solid;
+    border-width: thin;
+    padding: 0.5rem 2rem;
+  }
+}


### PR DESCRIPTION
closes #2147 

Allows HTML tables to be used in a record's description through the API or CKEditor in the deposit form