### PR TITLE
homepage: update twitter feed to latest version

### DIFF
--- a/zenodo/modules/frontpage/templates/zenodo_frontpage/index.html
+++ b/zenodo/modules/frontpage/templates/zenodo_frontpage/index.html
@@ -266,7 +266,8 @@
       </div>
 
       <div class="hidden-xs">
-        <a class="twitter-timeline" href="https://twitter.com/ZENODO_ORG" data-widget-id="331751059422855169"></a>
+        <a class="twitter-timeline" data-lang="en" data-width="360" data-height="600" data-dnt="true"
+           href="https://twitter.com/ZENODO_ORG"></a>
       </div>
     </div>
   </div>
@@ -274,7 +275,7 @@
 {%- endblock page_body %}
 
 {% block javascript %}
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 {{ super() }}
 <script type="text/javascript">
 $(function () {


### PR DESCRIPTION
This fixes the deprecation warning, there is another console-logged comment regarding the Twitter feed, but it seems irrelevant to this issue.