### PR TITLE
pydocstyle: fix styling errors

### DIFF
--- a/zenodo/modules/records/views.py
+++ b/zenodo/modules/records/views.py
@@ -108,6 +108,7 @@ def is_safelisted_record(record):
 
 @blueprint.app_template_test('safelisted_user')
 def is_safelisted_user(user):
+    """Check if a user is safelisted."""
     return is_user_safelisted(user)
 
 @blueprint.app_template_filter('pidstatus')

--- a/zenodo/modules/spam/tasks.py
+++ b/zenodo/modules/spam/tasks.py
@@ -58,6 +58,7 @@ def check_metadata_for_spam(community_id=None, dep_id=None):
 
 @shared_task(ignore_result=False)
 def delete_record(record_uuid, reason, user):
+    """Run delete_record as a task."""
     from zenodo.modules.deposit import utils as deposit_utils
 
     deposit_utils.delete_record(record_uuid, reason, user)
@@ -66,7 +67,6 @@ def delete_record(record_uuid, reason, user):
 @shared_task(ignore_result=False)
 def delete_spam_user(user_id, deleted_by):
     """Deletes a user and marks their records and communities as spam."""
-
     user = User.query.get(user_id)
     communities = Community.query.filter_by(id_user=user.id)
     rs = RecordsSearch(index='records').filter('term', owners=user.id)

--- a/zenodo/modules/spam/utils.py
+++ b/zenodo/modules/spam/utils.py
@@ -44,6 +44,7 @@ from zenodo.modules.spam.models import SafelistEntry
 
 
 def is_user_safelisted(user):
+    """Check if user is safelisted."""
     if not SafelistEntry.query.get(user.id):
         return False
     return True

--- a/zenodo/modules/spam/views.py
+++ b/zenodo/modules/spam/views.py
@@ -129,7 +129,7 @@ def delete(user_id):
         return render_template('zenodo_spam/delete.html', **ctx)
 
 
-def normalize_email(email):
+def _normalize_email(email):
     email = email.lower()
     username, domain = email.rsplit("@", 1)
     no_dots_username = username.replace(".", "")
@@ -139,14 +139,14 @@ def normalize_email(email):
     return no_dots_username + "@" + domain
 
 
-def get_domain(email):
+def _get_domain(email):
     return email[email.index("@") :].lower()
 
 
 def _evaluate_user_domain(email, normalized_emails, email_domain_count):
-    email_domain = get_domain(email)
+    email_domain = _get_domain(email)
     is_flagged_domain = email_domain in ["@gmail.com"]
-    is_above_threshold = normalized_emails.get(normalize_email(email), 0) > 3
+    is_above_threshold = normalized_emails.get(_normalize_email(email), 0) > 3
 
     domain_counts = email_domain_count[email_domain[1:]]
     domain_info = {
@@ -178,7 +178,7 @@ def _expand_users_info(results, include_pending=False):
     )
 
     normalized_emails = Counter([
-        normalize_email(user.email)
+        _normalize_email(user.email)
         for user in user_data
     ])
 


### PR DESCRIPTION
Running `pydocstyle zenodo tests docs` doesn't generate any warnings anymore.